### PR TITLE
VP/min 105 fix minterest model setters

### DIFF
--- a/pallets/controller/src/lib.rs
+++ b/pallets/controller/src/lib.rs
@@ -300,6 +300,8 @@ pub mod module {
 		}
 
 		/// Set insurance factor.
+		/// - `pool_id`: PoolID for which the parameter value is being set.
+		/// - `new_insurance_factor`: new value for insurance factor.
 		///
 		/// The dispatch origin of this call must be 'UpdateOrigin'.
 		#[pallet::weight(0)]
@@ -307,17 +309,13 @@ pub mod module {
 		pub fn set_insurance_factor(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			new_amount_n: u128,
-			new_amount_d: u128,
+			new_insurance_factor: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::UpdateOrigin::ensure_origin(origin)?;
 			ensure!(
 				T::LiquidityPoolsManager::pool_exists(&pool_id),
 				Error::<T>::PoolNotFound
 			);
-
-			let new_insurance_factor =
-				Rate::checked_from_rational(new_amount_n, new_amount_d).ok_or(Error::<T>::NumOverflow)?;
 
 			ControllerDates::<T>::mutate(pool_id, |r| r.insurance_factor = new_insurance_factor);
 			Self::deposit_event(Event::InsuranceFactorChanged);
@@ -325,6 +323,8 @@ pub mod module {
 		}
 
 		/// Set Maximum borrow rate.
+		/// - `pool_id`: PoolID for which the parameter value is being set.
+		/// - `new_max_borow_rate`: new value for maximum borrow rate.
 		///
 		/// The dispatch origin of this call must be 'UpdateOrigin'.
 		#[pallet::weight(0)]
@@ -332,17 +332,13 @@ pub mod module {
 		pub fn set_max_borrow_rate(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			new_amount_n: u128,
-			new_amount_d: u128,
+			new_max_borow_rate: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::UpdateOrigin::ensure_origin(origin)?;
 			ensure!(
 				T::LiquidityPoolsManager::pool_exists(&pool_id),
 				Error::<T>::PoolNotFound
 			);
-
-			let new_max_borow_rate =
-				Rate::checked_from_rational(new_amount_n, new_amount_d).ok_or(Error::<T>::NumOverflow)?;
 
 			ensure!(!new_max_borow_rate.is_zero(), Error::<T>::MaxBorrowRateCannotBeZero);
 
@@ -352,6 +348,8 @@ pub mod module {
 		}
 
 		/// Set Collateral factor.
+		/// - `pool_id`: PoolID for which the parameter value is being set.
+		/// - `new_collateral_factor`: new value for collateral factor.
 		///
 		/// The dispatch origin of this call must be 'UpdateOrigin'.
 		#[pallet::weight(0)]
@@ -359,17 +357,13 @@ pub mod module {
 		pub fn set_collateral_factor(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			new_amount_n: u128,
-			new_amount_d: u128,
+			new_collateral_factor: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::UpdateOrigin::ensure_origin(origin)?;
 			ensure!(
 				T::LiquidityPoolsManager::pool_exists(&pool_id),
 				Error::<T>::PoolNotFound
 			);
-
-			let new_collateral_factor =
-				Rate::checked_from_rational(new_amount_n, new_amount_d).ok_or(Error::<T>::NumOverflow)?;
 
 			ensure!(
 				new_collateral_factor <= Rate::one(),

--- a/pallets/integration-tests/src/tests/controller_tests.rs
+++ b/pallets/integration-tests/src/tests/controller_tests.rs
@@ -119,7 +119,11 @@ mod tests {
 				System::set_block_number(10);
 
 				// Set insurance factor equal 0.5.
-				assert_ok!(TestController::set_insurance_factor(admin(), CurrencyId::DOT, 1, 2));
+				assert_ok!(TestController::set_insurance_factor(
+					admin(),
+					CurrencyId::DOT,
+					Rate::saturating_from_rational(1, 2)
+				));
 
 				// Alice repay full loan in DOTs.
 				assert_ok!(MinterestProtocol::repay_all(Origin::signed(ALICE), CurrencyId::DOT));
@@ -181,7 +185,11 @@ mod tests {
 				System::set_block_number(10);
 
 				// Set insurance factor equal to zero.
-				assert_ok!(TestController::set_insurance_factor(admin(), CurrencyId::DOT, 0, 1));
+				assert_ok!(TestController::set_insurance_factor(
+					admin(),
+					CurrencyId::DOT,
+					RATE_ZERO
+				));
 
 				// Alice repay full loan in DOTs.
 				assert_ok!(MinterestProtocol::repay_all(Origin::signed(ALICE), CurrencyId::DOT));

--- a/pallets/minterest-model/src/lib.rs
+++ b/pallets/minterest-model/src/lib.rs
@@ -176,7 +176,7 @@ pub mod module {
 
 			// jump_multiplier_per_block = jump_multiplier_rate_per_year / blocks_per_year
 			let new_jump_multiplier_per_block = jump_multiplier_rate_per_year
-				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
+				.checked_div(&Rate::saturating_from_integer(T::BlocksPerYear::get()))
 				.ok_or(Error::<T>::NumOverflow)?;
 
 			// Write the previously calculated values into storage.
@@ -248,7 +248,7 @@ pub mod module {
 			);
 
 			let new_multiplier_per_block = multiplier_per_year
-				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
+				.checked_div(&Rate::saturating_from_integer(T::BlocksPerYear::get()))
 				.ok_or(Error::<T>::NumOverflow)?;
 
 			// Multiplier per block cannot be set to 0 at the same time as Base rate per block .

--- a/pallets/minterest-model/src/lib.rs
+++ b/pallets/minterest-model/src/lib.rs
@@ -156,19 +156,16 @@ pub mod module {
 	impl<T: Config> Pallet<T> {
 		/// Set JumpMultiplierPerBlock from JumpMultiplierPerYear.
 		/// - `pool_id`: PoolID for which the parameter value is being set.
-		/// - `jump_multiplier_rate_per_year_n`: numerator.
-		/// - `jump_multiplier_rate_per_year_d`: divider.
+		/// - `jump_multiplier_rate_per_year`: used to calculate multiplier per block.
 		///
-		/// `jump_multiplier_per_block = (jump_multiplier_rate_per_year_n /
-		/// jump_multiplier_rate_per_year_d) / blocks_per_year` The dispatch origin of this call
-		/// must be 'ModelUpdateOrigin'.
+		/// `jump_multiplier_per_block = jump_multiplier_rate_per_year / blocks_per_year`
+		/// The dispatch origin of this call must be 'ModelUpdateOrigin'.
 		#[pallet::weight(0)]
 		#[transactional]
-		pub fn set_jump_multiplier_per_block(
+		pub fn set_jump_multiplier_per_year(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			jump_multiplier_rate_per_year_n: u128,
-			jump_multiplier_rate_per_year_d: u128,
+			jump_multiplier_rate_per_year: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::ModelUpdateOrigin::ensure_origin(origin)?;
 
@@ -177,12 +174,8 @@ pub mod module {
 				Error::<T>::NotValidUnderlyingAssetId
 			);
 
-			// jump_multiplier_per_block = (jump_multiplier_rate_per_year_n / jump_multiplier_rate_per_year_d) /
-			// blocks_per_year
-			let new_jump_multiplier_per_year =
-				Rate::checked_from_rational(jump_multiplier_rate_per_year_n, jump_multiplier_rate_per_year_d)
-					.ok_or(Error::<T>::NumOverflow)?;
-			let new_jump_multiplier_per_block = new_jump_multiplier_per_year
+			// jump_multiplier_per_block = jump_multiplier_rate_per_year / blocks_per_year
+			let new_jump_multiplier_per_block = jump_multiplier_rate_per_year
 				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
 				.ok_or(Error::<T>::NumOverflow)?;
 
@@ -196,18 +189,16 @@ pub mod module {
 
 		/// Set BaseRatePerBlock from BaseRatePerYear.
 		/// - `pool_id`: PoolID for which the parameter value is being set.
-		/// - `base_rate_per_year_n`: numerator.
-		/// - `base_rate_per_year_d`: divider.
+		/// - `base_rate_per_year`: used to calculate rate per block.
 		///
-		/// `base_rate_per_block = base_rate_per_year_n / base_rate_per_year_d`
+		/// `base_rate_per_block = base_rate_per_year / blocks_per_year`
 		/// The dispatch origin of this call must be 'ModelUpdateOrigin'.
 		#[pallet::weight(0)]
 		#[transactional]
-		pub fn set_base_rate_per_block(
+		pub fn set_base_rate_per_year(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			base_rate_per_year_n: u128,
-			base_rate_per_year_d: u128,
+			base_rate_per_year: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::ModelUpdateOrigin::ensure_origin(origin)?;
 
@@ -216,9 +207,7 @@ pub mod module {
 				Error::<T>::NotValidUnderlyingAssetId
 			);
 
-			let new_base_rate_per_year = Rate::checked_from_rational(base_rate_per_year_n, base_rate_per_year_d)
-				.ok_or(Error::<T>::NumOverflow)?;
-			let new_base_rate_per_block = new_base_rate_per_year
+			let new_base_rate_per_block = base_rate_per_year
 				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
 				.ok_or(Error::<T>::NumOverflow)?;
 
@@ -240,18 +229,16 @@ pub mod module {
 
 		/// Set MultiplierPerBlock from MultiplierPerYear.
 		/// - `pool_id`: PoolID for which the parameter value is being set.
-		/// - `multiplier_rate_per_year_n`: numerator.
-		/// - `multiplier_rate_per_year_d`: divider.
+		/// - `multiplier_per_year`: used to calculate multiplier per block.
 		///
-		/// `multiplier_per_block = (multiplier_rate_per_year_n / multiplier_rate_per_year_d) /
-		/// blocks_per_year` The dispatch origin of this call must be 'ModelUpdateOrigin'.
+		/// `multiplier_per_block = multiplier_per_year / blocks_per_year`
+		/// The dispatch origin of this call must be 'ModelUpdateOrigin'.
 		#[pallet::weight(0)]
 		#[transactional]
-		pub fn set_multiplier_per_block(
+		pub fn set_multiplier_per_year(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			multiplier_rate_per_year_n: u128,
-			multiplier_rate_per_year_d: u128,
+			multiplier_per_year: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::ModelUpdateOrigin::ensure_origin(origin)?;
 
@@ -260,10 +247,7 @@ pub mod module {
 				Error::<T>::NotValidUnderlyingAssetId
 			);
 
-			let new_multiplier_per_year =
-				Rate::checked_from_rational(multiplier_rate_per_year_n, multiplier_rate_per_year_d)
-					.ok_or(Error::<T>::NumOverflow)?;
-			let new_multiplier_per_block = new_multiplier_per_year
+			let new_multiplier_per_block = multiplier_per_year
 				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
 				.ok_or(Error::<T>::NumOverflow)?;
 

--- a/pallets/minterest-model/src/lib.rs
+++ b/pallets/minterest-model/src/lib.rs
@@ -208,7 +208,7 @@ pub mod module {
 			);
 
 			let new_base_rate_per_block = base_rate_per_year
-				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
+				.checked_div(&Rate::saturating_from_integer(T::BlocksPerYear::get()))
 				.ok_or(Error::<T>::NumOverflow)?;
 
 			// Base rate per block cannot be set to 0 at the same time as Multiplier per block.

--- a/pallets/minterest-model/src/tests.rs
+++ b/pallets/minterest-model/src/tests.rs
@@ -210,7 +210,11 @@ fn set_jump_multiplier_per_year_should_work() {
 #[test]
 fn set_kink_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(TestMinterestModel::set_kink(alice(), CurrencyId::DOT, 8, 10));
+		assert_ok!(TestMinterestModel::set_kink(
+			alice(),
+			CurrencyId::DOT,
+			Rate::saturating_from_rational(8, 10)
+		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).kink,
 			Rate::saturating_from_rational(8, 10)
@@ -218,24 +222,21 @@ fn set_kink_should_work() {
 		let expected_event = Event::minterest_model(crate::Event::KinkHasChanged);
 		assert!(System::events().iter().any(|record| record.event == expected_event));
 
-		// Overflow in calculation: 0 / 0
-		assert_noop!(
-			TestMinterestModel::set_kink(alice(), CurrencyId::DOT, 0, 0),
-			Error::<Test>::NumOverflow
-		);
-
 		// The dispatch origin of this call must be Root or half MinterestCouncil.
-		assert_noop!(TestMinterestModel::set_kink(bob(), CurrencyId::DOT, 8, 10), BadOrigin);
+		assert_noop!(
+			TestMinterestModel::set_kink(bob(), CurrencyId::DOT, Rate::saturating_from_rational(8, 10)),
+			BadOrigin
+		);
 
 		// MDOT is wrong CurrencyId for underlying assets.
 		assert_noop!(
-			TestMinterestModel::set_kink(alice(), CurrencyId::MDOT, 8, 10),
+			TestMinterestModel::set_kink(alice(), CurrencyId::MDOT, Rate::saturating_from_rational(8, 10)),
 			Error::<Test>::NotValidUnderlyingAssetId
 		);
 
 		// Parameter `kink` cannot be more than one.
 		assert_noop!(
-			TestMinterestModel::set_kink(alice(), CurrencyId::DOT, 18, 10),
+			TestMinterestModel::set_kink(alice(), CurrencyId::DOT, Rate::saturating_from_rational(11, 10)),
 			Error::<Test>::KinkCannotBeMoreThanOne
 		);
 	});

--- a/pallets/minterest-model/src/tests.rs
+++ b/pallets/minterest-model/src/tests.rs
@@ -25,14 +25,13 @@ fn base_rate_per_block_equal_max_value() -> MinterestModelData {
 }
 
 #[test]
-fn set_base_rate_per_block_should_work() {
+fn set_base_rate_per_year_should_work() {
 	new_test_ext().execute_with(|| {
 		// Set Base rate per block equal 2.0: (10_512_000 / 1) / 5_256_000
-		assert_ok!(TestMinterestModel::set_base_rate_per_block(
+		assert_ok!(TestMinterestModel::set_base_rate_per_year(
 			alice(),
 			CurrencyId::DOT,
-			10_512_000,
-			1
+			Rate::saturating_from_rational(10_512_000, 1)
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).base_rate_per_block,
@@ -42,11 +41,10 @@ fn set_base_rate_per_block_should_work() {
 		assert!(System::events().iter().any(|record| record.event == expected_event));
 
 		// Can be set to 0.0: (0 / 10) / 5_256_000
-		assert_ok!(TestMinterestModel::set_base_rate_per_block(
+		assert_ok!(TestMinterestModel::set_base_rate_per_year(
 			alice(),
 			CurrencyId::DOT,
-			0,
-			1
+			Rate::zero()
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).base_rate_per_block,
@@ -54,11 +52,10 @@ fn set_base_rate_per_block_should_work() {
 		);
 
 		// ALICE set Baser rate per block equal 0,000000009: (47_304 / 1_000_000) / 5_256_000
-		assert_ok!(TestMinterestModel::set_base_rate_per_block(
+		assert_ok!(TestMinterestModel::set_base_rate_per_year(
 			alice(),
 			CurrencyId::DOT,
-			47304,
-			1_000_000
+			Rate::saturating_from_rational(47304, 1_000_000)
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).base_rate_per_block,
@@ -66,46 +63,38 @@ fn set_base_rate_per_block_should_work() {
 		);
 
 		// Base rate per block cannot be set to 0 at the same time as Multiplier per block.
-		assert_ok!(TestMinterestModel::set_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			0,
-			1
+			Rate::zero()
 		));
 		assert_noop!(
-			TestMinterestModel::set_base_rate_per_block(alice(), CurrencyId::DOT, 0, 1),
+			TestMinterestModel::set_base_rate_per_year(alice(), CurrencyId::DOT, Rate::zero()),
 			Error::<Test>::BaseRatePerBlockCannotBeZero
-		);
-
-		// Overflow in calculation: 20 / 0
-		assert_noop!(
-			TestMinterestModel::set_base_rate_per_block(alice(), CurrencyId::DOT, 20, 0),
-			Error::<Test>::NumOverflow
 		);
 
 		// The dispatch origin of this call must be Root or half MinterestCouncil.
 		assert_noop!(
-			TestMinterestModel::set_base_rate_per_block(bob(), CurrencyId::DOT, 20, 10),
+			TestMinterestModel::set_base_rate_per_year(bob(), CurrencyId::DOT, Rate::from_inner(2)),
 			BadOrigin
 		);
 
 		// MDOT is wrong CurrencyId for underlying assets.
 		assert_noop!(
-			TestMinterestModel::set_base_rate_per_block(alice(), CurrencyId::MDOT, 20, 10),
+			TestMinterestModel::set_base_rate_per_year(alice(), CurrencyId::MDOT, Rate::from_inner(2)),
 			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});
 }
 
 #[test]
-fn set_multiplier_per_block_should_work() {
+fn set_multiplier_per_year_should_work() {
 	new_test_ext().execute_with(|| {
 		// Set Multiplier per block equal 2.0: (10_512_000 / 1) / 5_256_000
-		assert_ok!(TestMinterestModel::set_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			10_512_000,
-			1
+			Rate::saturating_from_rational(10_512_000, 1)
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).multiplier_per_block,
@@ -115,17 +104,15 @@ fn set_multiplier_per_block_should_work() {
 		assert!(System::events().iter().any(|record| record.event == expected_event));
 
 		// Can be set to 0.0 if Base rate per block grater than zero: (0 / 10) / 5_256_000
-		assert_ok!(TestMinterestModel::set_base_rate_per_block(
+		assert_ok!(TestMinterestModel::set_base_rate_per_year(
 			alice(),
 			CurrencyId::DOT,
-			1,
-			1
+			Rate::one()
 		));
-		assert_ok!(TestMinterestModel::set_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			0,
-			10
+			Rate::zero()
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).multiplier_per_block,
@@ -133,11 +120,10 @@ fn set_multiplier_per_block_should_work() {
 		);
 
 		// Alice set Multiplier per block equal 0,000_000_009: (47_304 / 1_000_000) / 5_256_000
-		assert_ok!(TestMinterestModel::set_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			47304,
-			1_000_000
+			Rate::saturating_from_rational(47304, 1_000_000)
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).multiplier_per_block,
@@ -145,46 +131,38 @@ fn set_multiplier_per_block_should_work() {
 		);
 
 		//  Multiplier per block cannot be set to 0 at the same time as Base rate per block.
-		assert_ok!(TestMinterestModel::set_base_rate_per_block(
+		assert_ok!(TestMinterestModel::set_base_rate_per_year(
 			alice(),
 			CurrencyId::DOT,
-			0,
-			1
+			Rate::zero()
 		));
 		assert_noop!(
-			TestMinterestModel::set_multiplier_per_block(alice(), CurrencyId::DOT, 0, 1),
+			TestMinterestModel::set_multiplier_per_year(alice(), CurrencyId::DOT, Rate::zero()),
 			Error::<Test>::MultiplierPerBlockCannotBeZero
-		);
-
-		// Overflow in calculation: 20 / 0
-		assert_noop!(
-			TestMinterestModel::set_multiplier_per_block(alice(), CurrencyId::DOT, 20, 0),
-			Error::<Test>::NumOverflow
 		);
 
 		// The dispatch origin of this call must be Root or half MinterestCouncil.
 		assert_noop!(
-			TestMinterestModel::set_multiplier_per_block(bob(), CurrencyId::DOT, 20, 10),
+			TestMinterestModel::set_multiplier_per_year(bob(), CurrencyId::DOT, Rate::from_inner(2)),
 			BadOrigin
 		);
 
 		// MDOT is wrong CurrencyId for underlying assets.
 		assert_noop!(
-			TestMinterestModel::set_base_rate_per_block(alice(), CurrencyId::MDOT, 20, 10),
+			TestMinterestModel::set_base_rate_per_year(alice(), CurrencyId::MDOT, Rate::from_inner(2)),
 			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});
 }
 
 #[test]
-fn set_jump_multiplier_per_block_should_work() {
+fn set_jump_multiplier_per_year_should_work() {
 	new_test_ext().execute_with(|| {
 		// Set Jump multiplier per block equal 2.0: (10_512_000 / 1) / 5_256_000
-		assert_ok!(TestMinterestModel::set_jump_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_jump_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			10_512_000,
-			1
+			Rate::saturating_from_rational(10_512_000, 1)
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).jump_multiplier_per_block,
@@ -194,11 +172,10 @@ fn set_jump_multiplier_per_block_should_work() {
 		assert!(System::events().iter().any(|record| record.event == expected_event));
 
 		// Can be set to 0.0: (0 / 10) / 5_256_000
-		assert_ok!(TestMinterestModel::set_jump_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_jump_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			0,
-			10
+			Rate::zero()
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).jump_multiplier_per_block,
@@ -206,32 +183,25 @@ fn set_jump_multiplier_per_block_should_work() {
 		);
 
 		// Alice set Jump multiplier per block equal 0,000_000_009: (47_304 / 1_000_000) / 5_256_000
-		assert_ok!(TestMinterestModel::set_jump_multiplier_per_block(
+		assert_ok!(TestMinterestModel::set_jump_multiplier_per_year(
 			alice(),
 			CurrencyId::DOT,
-			47_304,
-			1_000_000
+			Rate::saturating_from_rational(47_304, 1_000_000)
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).jump_multiplier_per_block,
 			Rate::from_inner(9_000_000_000)
 		);
 
-		// Overflow in calculation: 20 / 0
-		assert_noop!(
-			TestMinterestModel::set_jump_multiplier_per_block(alice(), CurrencyId::DOT, 20, 0),
-			Error::<Test>::NumOverflow
-		);
-
 		// The dispatch origin of this call must be Root or half MinterestCouncil.
 		assert_noop!(
-			TestMinterestModel::set_jump_multiplier_per_block(bob(), CurrencyId::DOT, 20, 10),
+			TestMinterestModel::set_jump_multiplier_per_year(bob(), CurrencyId::DOT, Rate::from_inner(2)),
 			BadOrigin
 		);
 
 		// MDOT is wrong CurrencyId for underlying assets.
 		assert_noop!(
-			TestMinterestModel::set_base_rate_per_block(alice(), CurrencyId::MDOT, 20, 10),
+			TestMinterestModel::set_base_rate_per_year(alice(), CurrencyId::MDOT, Rate::from_inner(2)),
 			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});

--- a/pallets/risk-manager/src/lib.rs
+++ b/pallets/risk-manager/src/lib.rs
@@ -283,18 +283,15 @@ pub mod module {
 
 		/// Set threshold which used in liquidation to protect the user from micro liquidations..
 		/// - `pool_id`: PoolID for which the parameter value is being set.
-		/// - `new_threshold_n`: numerator.
-		/// - `new_threshold_d`: divider.
+		/// - `new_threshold`: new threshold.
 		///
-		/// `new_threshold = (new_threshold_n / new_threshold_d)`
 		/// The dispatch origin of this call must be 'UpdateOrigin'.
 		#[pallet::weight(0)]
 		#[transactional]
 		pub fn set_threshold(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			new_threshold_n: u128,
-			new_threshold_d: u128,
+			new_threshold: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::UpdateOrigin::ensure_origin(origin)?;
 
@@ -302,9 +299,6 @@ pub mod module {
 				<LiquidityPools<T>>::is_enabled_underlying_asset_id(pool_id),
 				Error::<T>::NotValidUnderlyingAssetId
 			);
-
-			let new_threshold =
-				Rate::checked_from_rational(new_threshold_n, new_threshold_d).ok_or(Error::<T>::NumOverflow)?;
 
 			// Write new value into storage.
 			RiskManagerDates::<T>::mutate(pool_id, |r| r.threshold = new_threshold);
@@ -316,18 +310,15 @@ pub mod module {
 
 		/// Set Liquidation fee that covers liquidation costs.
 		/// - `pool_id`: PoolID for which the parameter value is being set.
-		/// - `new_liquidation_incentive_n`: numerator.
-		/// - `new_liquidation_incentive_d`: divider.
+		/// - `new_liquidation_incentive`: new liquidation incentive.
 		///
-		/// `new_liquidation_incentive = (new_liquidation_incentive_n /
-		/// new_liquidation_incentive_d)` The dispatch origin of this call must be 'UpdateOrigin'.
+		/// The dispatch origin of this call must be 'UpdateOrigin'.
 		#[pallet::weight(0)]
 		#[transactional]
 		pub fn set_liquidation_incentive(
 			origin: OriginFor<T>,
 			pool_id: CurrencyId,
-			new_liquidation_incentive_n: u128,
-			new_liquidation_incentive_d: u128,
+			new_liquidation_incentive: Rate,
 		) -> DispatchResultWithPostInfo {
 			T::UpdateOrigin::ensure_origin(origin)?;
 
@@ -335,10 +326,6 @@ pub mod module {
 				<LiquidityPools<T>>::is_enabled_underlying_asset_id(pool_id),
 				Error::<T>::NotValidUnderlyingAssetId
 			);
-
-			let new_liquidation_incentive =
-				Rate::checked_from_rational(new_liquidation_incentive_n, new_liquidation_incentive_d)
-					.ok_or(Error::<T>::NumOverflow)?;
 
 			// Check if 1 <= new_liquidation_incentive <= 1.5
 			ensure!(

--- a/pallets/risk-manager/src/tests.rs
+++ b/pallets/risk-manager/src/tests.rs
@@ -77,7 +77,7 @@ fn set_min_sum_should_work() {
 fn set_threshold_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Can be set to 0.0
-		assert_ok!(TestRiskManager::set_threshold(admin(), CurrencyId::DOT, 0, 1));
+		assert_ok!(TestRiskManager::set_threshold(admin(), CurrencyId::DOT, Rate::zero()));
 		assert_eq!(
 			TestRiskManager::risk_manager_dates(CurrencyId::DOT).threshold,
 			Rate::zero()
@@ -86,7 +86,7 @@ fn set_threshold_should_work() {
 		assert!(System::events().iter().any(|record| record.event == expected_event));
 
 		// ALICE set min_sum equal one hundred.
-		assert_ok!(TestRiskManager::set_threshold(admin(), CurrencyId::DOT, 1, 1));
+		assert_ok!(TestRiskManager::set_threshold(admin(), CurrencyId::DOT, Rate::one()));
 		assert_eq!(
 			TestRiskManager::risk_manager_dates(CurrencyId::DOT).threshold,
 			Rate::one()
@@ -96,13 +96,13 @@ fn set_threshold_should_work() {
 
 		// The dispatch origin of this call must be Administrator.
 		assert_noop!(
-			TestRiskManager::set_threshold(alice(), CurrencyId::DOT, 1, 1),
+			TestRiskManager::set_threshold(alice(), CurrencyId::DOT, Rate::one()),
 			BadOrigin
 		);
 
 		// MDOT is wrong CurrencyId for underlying assets.
 		assert_noop!(
-			TestRiskManager::set_threshold(admin(), CurrencyId::MDOT, 1, 1),
+			TestRiskManager::set_threshold(admin(), CurrencyId::MDOT, Rate::one()),
 			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});
@@ -115,8 +115,7 @@ fn set_liquidation_incentive_should_work() {
 		assert_ok!(TestRiskManager::set_liquidation_incentive(
 			admin(),
 			CurrencyId::DOT,
-			1,
-			1
+			Rate::one()
 		));
 		assert_eq!(
 			TestRiskManager::risk_manager_dates(CurrencyId::DOT).liquidation_incentive,
@@ -127,25 +126,25 @@ fn set_liquidation_incentive_should_work() {
 
 		// Can not be set to 0.0
 		assert_noop!(
-			TestRiskManager::set_liquidation_incentive(admin(), CurrencyId::DOT, 0, 1),
+			TestRiskManager::set_liquidation_incentive(admin(), CurrencyId::DOT, Rate::zero()),
 			Error::<Test>::InvalidLiquidationIncentiveValue
 		);
 
 		// Can not be set to 2.0
 		assert_noop!(
-			TestRiskManager::set_liquidation_incentive(admin(), CurrencyId::DOT, 2, 1),
+			TestRiskManager::set_liquidation_incentive(admin(), CurrencyId::DOT, Rate::saturating_from_integer(2)),
 			Error::<Test>::InvalidLiquidationIncentiveValue
 		);
 
 		// The dispatch origin of this call must be Administrator.
 		assert_noop!(
-			TestRiskManager::set_liquidation_incentive(alice(), CurrencyId::DOT, 1, 1),
+			TestRiskManager::set_liquidation_incentive(alice(), CurrencyId::DOT, Rate::one()),
 			BadOrigin
 		);
 
 		// MDOT is wrong CurrencyId for underlying assets.
 		assert_noop!(
-			TestRiskManager::set_liquidation_incentive(admin(), CurrencyId::MDOT, 1, 1),
+			TestRiskManager::set_liquidation_incentive(admin(), CurrencyId::MDOT, Rate::one()),
 			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});


### PR DESCRIPTION
**Description:**

Naming:
set_jump_multiplier_per_block -> set_jump_multiplier_per_year
set_base_rate_per_block -> set_base_rate_per_year
set_multiplier_per_block -> set_multiplier_per_year

Made setters accept new values as a Rate instead of nominator and denominator:
- set_jump_multiplier_per_year
- set_base_rate_per_year
- set_multiplier_per_year
- set_kink
- set_insurance_factor
- set_max_borrow_rate
- set_collateral_factor
- set_threshold
- set_liquidation_incentive