### PR TITLE
[MIN-99] Variable transaction fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,6 +4184,7 @@ dependencies = [
  "parity-scale-codec",
  "risk-manager",
  "serde",
+ "smallvec 1.6.1",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -51,6 +51,7 @@ sp-session = { default-features = false, version = '3.0.0' }
 sp-std = { default-features = false, version = '3.0.0' }
 sp-transaction-pool = { default-features = false, version = '3.0.0' }
 sp-version = { default-features = false, version = '3.0.0' }
+smallvec = { default-features = false, version = '1.6.0' }
 
 # local dependencies
 mnt-token = { path = "../pallets/mnt-token", default-features = false }

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -35,3 +35,27 @@ pub const PROTOCOL_INTEREST_TRANSFER_THRESHOLD: minterest_primitives::Balance = 
 
 /// Initial exchange rate: 100%
 pub const INITIAL_EXCHANGE_RATE: Rate = Rate::from_inner(1_000_000_000_000_000_000);
+
+pub mod fee {
+	use frame_support::weights::constants::ExtrinsicBaseWeight;
+	use frame_support::weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial};
+	use minterest_primitives::Balance;
+	use smallvec::smallvec;
+	use sp_runtime::Perbill;
+
+	pub struct WeightToFee;
+	impl WeightToFeePolynomial for WeightToFee {
+		type Balance = Balance;
+		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+			// Extrinsic base weight is mapped to 0.43 MNT
+			let p = 426_974_397_875_000_000;
+			let q = Balance::from(ExtrinsicBaseWeight::get()); // 125_000_000
+			smallvec![WeightToFeeCoefficient {
+				degree: 1,
+				negative: false,
+				coeff_frac: Perbill::zero(), // zero
+				coeff_integer: p / q,        // 3_415_795_183
+			}]
+		}
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,13 +16,14 @@ mod tests;
 mod weights;
 mod weights_test;
 
+use crate::constants::fee::WeightToFee;
 pub use controller_rpc_runtime_api::PoolState;
 pub use controller_rpc_runtime_api::UserPoolBalanceData;
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::{create_median_value_data_provider, parameter_type_with_key, DataFeeder, DataProviderExtended};
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
-use pallet_transaction_payment::CurrencyAdapter;
+use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{
@@ -34,7 +35,7 @@ use sp_runtime::traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Bloc
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, DispatchResult, ModuleId,
+	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, ModuleId,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -60,7 +61,7 @@ pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-pub use sp_runtime::{Perbill, Permill};
+pub use sp_runtime::{Perbill, Permill, Perquintill};
 
 pub use constants::{currency::*, time::*, *};
 use frame_support::traits::Contains;
@@ -230,14 +231,18 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 3_570_000_000_000_000;
+	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
+	// FIXME: Temporary value to get multiplier equal to 1
+	pub AdjustmentVariable: Multiplier = Multiplier::zero();
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
 }
 
 impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = IdentityFee<Balance>;
-	type FeeMultiplierUpdate = ();
+	type WeightToFee = WeightToFee;
+	type FeeMultiplierUpdate = TargetedFeeAdjustment<Self, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -231,11 +231,11 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 3_570_000_000_000_000;
+	pub TransactionByteFee: Balance = 3_570_000_000_000_000;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);
 	// FIXME: Temporary value to get multiplier equal to 1
-	pub AdjustmentVariable: Multiplier = Multiplier::zero();
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::one();
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/service/src/chain_spec.rs
+++ b/service/src/chain_spec.rs
@@ -213,8 +213,8 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {
-			// Configure endowed accounts with initial balance of 1 << 60.
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+			// Configure endowed accounts with initial balance of INITIAL_BALANCE.
+			balances: endowed_accounts.iter().cloned().map(|k| (k, INITIAL_BALANCE)).collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),


### PR DESCRIPTION
**Description:**

Fix problem with stable fee for each tx. 
Add mod 'fee' where impl WeightToFeePolynomial trait.
According to new logic 1 weight equal to 3_415_785_183 of MNT token.
That means ExtrinsicBaseWeight (125_000_000) is mapped to 0.43 MNT

Update type FeeMultiplierUpdate for transaction_payment pallet.
Added this type we have got a mechanism which allows us to automatically change multiplier according to block fullness.
But it's stay stable for now, cause MinimumMultiplier is 1. It's temporary implementation.

Update TransactionByteFee. Now Each bite of  ex lenght costs 0.00357 MNT.

Update initial balance of Native token for endowed accounts.

 
**Changes in storage or API:**

**Checklist**

- [ ] Code is covered with tests
- [ ] Code is covered with benchmarks
- [ ] Fresh benchmark results included
