### PR TITLE
[MIN-9] Scripts for coverage report

### DIFF
--- a/covgen.sh
+++ b/covgen.sh
@@ -3,8 +3,7 @@
 # https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
 
 # Requirements:
-# cargo install rustfilt
-# cargo install cargo-binutils
+# cargo install cargo-binutils rustfilt
 # sudo apt install jq
 
 # Usage: ./covgen.sh <pallet_name>
@@ -18,17 +17,23 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
+# Go to pallet, compile tests and get binary path
 cd pallets/$1
 bin_path=$(RUSTFLAGS="-Zinstrument-coverage" cargo test --no-run --message-format=json \
     | jq -r "select(.profile.test == true) | .filenames[]")
 cd ../..
 
+# Run binary to generate profraw file
 LLVM_PROFILE_FILE="formatjson5.profraw" $bin_path
-cargo profdata -- merge -sparse  formatjson5.profraw -o json5format.profdata
 
+# Generate html coverage report
+cargo profdata -- merge -sparse  formatjson5.profraw -o json5format.profdata
 cargo cov -- show -Xdemangler=rustfilt $bin_path \
     --ignore-filename-regex='/.cargo/registry|toolchains/nightly|mock.rs|tests.rs' \
     --instr-profile=json5format.profdata -format=html -output-dir=./covgen/$1/
 
+
 rm formatjson5.profraw
 rm json5format.profdata
+# This artifact occasionaly apeears.
+rm default.profraw 2> /dev/null || true

--- a/covgen.sh
+++ b/covgen.sh
@@ -3,6 +3,7 @@
 # https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
 
 # Requirements:
+# rustup component add llvm-tools-preview
 # cargo install cargo-binutils rustfilt
 # sudo apt install jq
 
@@ -27,7 +28,7 @@ cd ../..
 LLVM_PROFILE_FILE="formatjson5.profraw" $bin_path
 
 # Generate html coverage report
-cargo profdata -- merge -sparse  formatjson5.profraw -o json5format.profdata
+cargo profdata -- merge -sparse formatjson5.profraw -o json5format.profdata
 cargo cov -- show -Xdemangler=rustfilt $bin_path \
     --ignore-filename-regex='/.cargo/registry|toolchains/nightly|mock.rs|tests.rs' \
     --instr-profile=json5format.profdata -format=html -output-dir=./covgen/$1/

--- a/covgen.sh
+++ b/covgen.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
+
+# Requirements:
+# cargo install rustfilt
+# cargo install cargo-binutils
+# sudo apt install jq
+
+# Usage: ./covgen.sh <pallet_name>
+
+# Output result path: ./covgen/<pallet_name>/index.html
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters. Example: ./covgen.sh <pallet_name>"
+    exit 1
+fi
+
+cd pallets/$1
+bin_path=$(RUSTFLAGS="-Zinstrument-coverage" cargo test --no-run --message-format=json \
+    | jq -r "select(.profile.test == true) | .filenames[]")
+cd ../..
+
+LLVM_PROFILE_FILE="formatjson5.profraw" $bin_path
+cargo profdata -- merge -sparse  formatjson5.profraw -o json5format.profdata
+
+cargo cov -- show -Xdemangler=rustfilt $bin_path \
+    --ignore-filename-regex='/.cargo/registry|toolchains/nightly|mock.rs|tests.rs' \
+    --instr-profile=json5format.profdata -format=html -output-dir=./covgen/$1/
+
+rm formatjson5.profraw
+rm json5format.profdata

--- a/covsum.sh
+++ b/covsum.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
+
+# Requirements:
+# cargo install rustfilt cargo-binutils
+# sudo apt install jq
+
+# Usage: ./covsum.sh or ./covsum.sh > result.json
+
+# How it works. It runs unit tests for each pallet and takes coverage only from lib.rs.
+
+# See information about lines and regions coverage
+# https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html#interpreting-reports
+
+# Add pallet-name here to include in coverage report
+Pallets=('risk-manager' 'controller' 'dex' \
+    'liquidation-pools' 'liquidity-pools' \
+    'minterest-model' 'mnt-token' 'prices')
+
+set -e
+
+summary='[]'
+
+for pallet_name in "${Pallets[@]}"; do
+    # Go to pallet, compile tests and get binary path
+    cd pallets/$pallet_name
+    bin_path=$(RUSTFLAGS="-Zinstrument-coverage" cargo test --no-run --message-format=json \
+        | jq -r "select(.profile.test == true) | .filenames[]")
+    cd ../..
+
+    # Run binary to generate profraw file
+    LLVM_PROFILE_FILE="formatjson5.profraw" $bin_path &> /dev/null
+
+    # Generate summary
+    cargo profdata -- merge -sparse  formatjson5.profraw -o json5format.profdata
+    cov_sum=$(cargo cov -- export -Xdemangler=rustfilt --format='text' \
+        --ignore-filename-regex='/.cargo/registry|toolchains/nightly|mock.rs|tests.rs' \
+        --instr-profile=json5format.profdata  -summary-only  --object $bin_path)
+    cov_result=$(echo $cov_sum | jq ".data[].files[] | select(.filename==\"pallets/$pallet_name/src/lib.rs\").summary |
+        {pallet: \"$pallet_name\", lines_coverage: .lines.percent, regions_coverage: .regions.percent}")
+
+    summary=$(echo $summary | jq ".[length] |= . + $cov_result")
+done
+
+echo $summary | jq
+
+rm formatjson5.profraw
+rm json5format.profdata
+# This artifact occasionaly apeears.
+rm default.profraw 2> /dev/null || true

--- a/covsum.sh
+++ b/covsum.sh
@@ -3,6 +3,7 @@
 # https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
 
 # Requirements:
+# rustup component add llvm-tools-preview
 # cargo install rustfilt cargo-binutils
 # sudo apt install jq
 
@@ -38,8 +39,10 @@ for pallet_name in "${Pallets[@]}"; do
         --ignore-filename-regex='/.cargo/registry|toolchains/nightly|mock.rs|tests.rs' \
         --instr-profile=json5format.profdata  -summary-only  --object $bin_path)
     cov_result=$(echo $cov_sum | jq ".data[].files[] | select(.filename==\"pallets/$pallet_name/src/lib.rs\").summary |
-        {pallet: \"$pallet_name\", lines_coverage: .lines.percent, regions_coverage: .regions.percent}")
-
+            {pallet: \"$pallet_name\",
+            lines_coverage: .lines.percent,
+            regions_coverage: .regions.percent,
+            functions_coverage: .functions.percent}")
     summary=$(echo $summary | jq ".[length] |= . + $cov_result")
 done
 


### PR DESCRIPTION
**Description:**

There are two scripts:
- **covgen.sh** to check coverage manually (generate html report) and look for missed regions
- **consum.sh** make summary for all pallets about code coverage

### Requirements:
- `rustup component add llvm-tools-preview`
-  `cargo install cargo-binutils rustfilt`
- ` sudo apt install jq`

**Changes in storage or API:**

Describe storage structure changes or API changes. Make sure to update the [API docs](https://minterestfinance.atlassian.net/wiki/spaces/MINTEREST/pages/134807557/Minterest+API).

**Checklist**

- [ ] Code is covered with tests
- [ ] Code is covered with benchmarks
- [ ] Fresh benchmark results included
