### PR TITLE
[MIN-330] Renamed traits for pallet to meet the convention

### DIFF
--- a/pallets/controller/rpc/runtime-api/src/lib.rs
+++ b/pallets/controller/rpc/runtime-api/src/lib.rs
@@ -1,4 +1,8 @@
 //! Runtime API definition for controller pallet.
+//! Here we declare the runtime API. It is implemented in the `impl` block in
+//! runtime amalgamator file (the `runtime/src/lib.rs`)
+//!
+//! Corresponding RPC declaration: `pallets/controller/rpc/src/lib.rs`
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // The `too_many_arguments` warning originates from `decl_runtime_apis` macro.
@@ -61,8 +65,6 @@ fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(dese
 		.map_err(|_| serde::de::Error::custom("Parse from string failed"))
 }
 
-// Here we declare the runtime API. It is implemented in the `impl` block in
-// runtime amalgamator file (the `runtime/src/lib.rs`)
 sp_api::decl_runtime_apis! {
 	pub trait ControllerRuntimeApi<AccountId>
 	where

--- a/pallets/controller/rpc/runtime-api/src/lib.rs
+++ b/pallets/controller/rpc/runtime-api/src/lib.rs
@@ -64,7 +64,7 @@ fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(dese
 // Here we declare the runtime API. It is implemented in the `impl` block in
 // runtime amalgamator file (the `runtime/src/lib.rs`)
 sp_api::decl_runtime_apis! {
-	pub trait ControllerApi<AccountId>
+	pub trait ControllerRuntimeApi<AccountId>
 	where
 		AccountId: Codec,
 	{

--- a/pallets/controller/rpc/src/lib.rs
+++ b/pallets/controller/rpc/src/lib.rs
@@ -13,13 +13,45 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
 #[rpc]
+/// Base trait for RPC interface of controller
 pub trait ControllerRpcApi<BlockHash, AccountId> {
+	/// Returns current Liquidity Pool State.
+	///
+	///  - `&self` :  Self reference
+	///  - `pool_id`: current pool id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - exchange_rate: the Exchange Rate between an mToken and the underlying asset.
+	///	is equal to:
+	/// 	exchange_rate = (total_cash + total_borrowed - total_protocol_interest) / total_supply;
+	/// 	- borrow_rate: Borrow Interest Rate
+	/// - supply_rate: current Supply Interest Rate.
+	/// 	The supply rate is derived from the borrow_rate and the amount of Total Borrowed.
 	#[rpc(name = "controller_liquidityPoolState")]
 	fn liquidity_pool_state(&self, pool_id: CurrencyId, at: Option<BlockHash>) -> Result<Option<PoolState>>;
 
+	/// Returns total supply and total borrowed balance in usd.
+	///
+	///  - `&self` :  Self reference
+	///  - `account_id`: current account id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - total_supply: total balance that user has in all pools converted to usd
+	/// - total_borrowed: total borrowed tokens from all pools converted to usd.
 	#[rpc(name = "controller_userBalanceInfo")]
 	fn get_user_balance(&self, account_id: AccountId, at: Option<BlockHash>) -> Result<Option<UserPoolBalanceData>>;
 
+	/// Returns account liquidity in usd.
+	///
+	///  - `&self` :  Self reference
+	///  - `account_id`: current account id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - liquidity: account liquidity in usd.
+	/// Positive amount if user has collateral greater than borrowed, otherwise negative.
 	#[rpc(name = "controller_accountLiquidity")]
 	fn get_hypothetical_account_liquidity(
 		&self,
@@ -27,12 +59,37 @@ pub trait ControllerRpcApi<BlockHash, AccountId> {
 		at: Option<BlockHash>,
 	) -> Result<Option<HypotheticalLiquidityData>>;
 
+	/// Checks whether the caller is a member of the MinterestCouncil.
+	///
+	///  - `&self` :  Self reference
+	///  - `account_id`: current account id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return
+	/// - is_admin: true / false
 	#[rpc(name = "controller_isAdmin")]
 	fn is_admin(&self, caller: AccountId, at: Option<BlockHash>) -> Result<Option<bool>>;
 
+	/// Returns account total collateral in usd.
+	///
+	///  - `&self` :  Self reference
+	///  - `account_id`: current account id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - amount: account total collateral converted to usd.
 	#[rpc(name = "controller_accountCollateral")]
 	fn get_user_total_collateral(&self, account_id: AccountId, at: Option<BlockHash>) -> Result<Option<BalanceInfo>>;
 
+	/// Returns actual borrow balance for user per asset based on fresh latest indexes.
+	///
+	///  - `&self` :  Self reference
+	///  - `account_id`: current account id.
+	///  - `underlying_asset_id`: current asset id
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - amount: account total borrow per asset.
 	#[rpc(name = "controller_getUserBorrowPerAsset")]
 	fn get_user_borrow_per_asset(
 		&self,
@@ -41,6 +98,14 @@ pub trait ControllerRpcApi<BlockHash, AccountId> {
 		at: Option<BlockHash>,
 	) -> Result<Option<BalanceInfo>>;
 
+	/// Checks whether the pool is created in storage.
+	///
+	///  - `&self` :  Self reference
+	///  - `underlying_asset_id`: current asset id
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - is_created: true / false
 	#[rpc(name = "controller_poolExists")]
 	fn pool_exists(&self, underlying_asset_id: CurrencyId, at: Option<BlockHash>) -> Result<bool>;
 }
@@ -52,7 +117,7 @@ pub struct ControllerRpcImpl<C, B> {
 }
 
 impl<C, B> ControllerRpcImpl<C, B> {
-	/// Create new `LiquidityPool` with the given reference to the client.
+	/// Create new `ControllerRpcImpl` with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self {
 			client,
@@ -73,6 +138,7 @@ impl From<Error> for i64 {
 	}
 }
 
+/// Implementation of 'ControllerRpcApi'
 impl<C, Block, AccountId> ControllerRpcApi<<Block as BlockT>::Hash, AccountId> for ControllerRpcImpl<C, Block>
 where
 	Block: BlockT,

--- a/pallets/controller/rpc/src/lib.rs
+++ b/pallets/controller/rpc/src/lib.rs
@@ -2,7 +2,7 @@
 
 use codec::Codec;
 pub use controller_rpc_runtime_api::{
-	BalanceInfo, ControllerApi as ControllerRuntimeApi, HypotheticalLiquidityData, PoolState, UserPoolBalanceData,
+	BalanceInfo, ControllerRuntimeApi, HypotheticalLiquidityData, PoolState, UserPoolBalanceData,
 };
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
@@ -13,7 +13,7 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
 #[rpc]
-pub trait ControllerApi<BlockHash, AccountId> {
+pub trait ControllerRpcApi<BlockHash, AccountId> {
 	#[rpc(name = "controller_liquidityPoolState")]
 	fn liquidity_pool_state(&self, pool_id: CurrencyId, at: Option<BlockHash>) -> Result<Option<PoolState>>;
 
@@ -46,12 +46,12 @@ pub trait ControllerApi<BlockHash, AccountId> {
 }
 
 /// A struct that implements the [`ControllerApi`].
-pub struct Controller<C, B> {
+pub struct ControllerRpcImpl<C, B> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<B>,
 }
 
-impl<C, B> Controller<C, B> {
+impl<C, B> ControllerRpcImpl<C, B> {
 	/// Create new `LiquidityPool` with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self {
@@ -73,7 +73,7 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block, AccountId> ControllerApi<<Block as BlockT>::Hash, AccountId> for Controller<C, Block>
+impl<C, Block, AccountId> ControllerRpcApi<<Block as BlockT>::Hash, AccountId> for ControllerRpcImpl<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/pallets/controller/src/lib.rs
+++ b/pallets/controller/src/lib.rs
@@ -17,7 +17,7 @@ use frame_system::pallet_prelude::*;
 use liquidity_pools::Pool;
 use minterest_primitives::{Balance, CurrencyId, Operation, Rate};
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerAPI, LiquidityPoolsManager, PoolsManager, PriceProvider};
+use pallet_traits::{ControllerManager, LiquidityPoolsManager, PoolsManager, PriceProvider};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::traits::CheckedSub;
@@ -847,7 +847,7 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> ControllerAPI<T::AccountId> for Pallet<T> {
+impl<T: Config> ControllerManager<T::AccountId> for Pallet<T> {
 	/// This is a part of a pool creation flow
 	/// Creates storage records for ControllerParams and PauseKeepers
 	/// All operations are unpaused after this function call

--- a/pallets/controller/src/lib.rs
+++ b/pallets/controller/src/lib.rs
@@ -17,7 +17,7 @@ use frame_system::pallet_prelude::*;
 use liquidity_pools::Pool;
 use minterest_primitives::{Balance, CurrencyId, Operation, Rate};
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerManager, LiquidityPoolsManager, PoolsManager, PriceProvider};
+use pallet_traits::{ControllerManager, LiquidityPoolsManager, PoolsManager, PricesManager};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::traits::CheckedSub;

--- a/pallets/controller/src/mock.rs
+++ b/pallets/controller/src/mock.rs
@@ -70,7 +70,7 @@ impl MockPriceSource {
 		UNDERLYING_PRICE.with(|v| *v.borrow_mut() = price);
 	}
 }
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		UNDERLYING_PRICE.with(|v| *v.borrow_mut())
 	}

--- a/pallets/dex/src/mock.rs
+++ b/pallets/dex/src/mock.rs
@@ -13,7 +13,7 @@ pub use minterest_primitives::{
 };
 pub(crate) use minterest_primitives::{Balance, CurrencyId, Price, Rate};
 use orml_traits::parameter_type_with_key;
-pub(crate) use pallet_traits::{LiquidationPoolsManager, PriceProvider};
+pub(crate) use pallet_traits::{LiquidationPoolsManager, PricesManager};
 use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, TestXt},
@@ -48,7 +48,7 @@ mock_impl_balances_config!(Runtime);
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		Some(Price::one())
 	}

--- a/pallets/integration-tests/src/lib.rs
+++ b/pallets/integration-tests/src/lib.rs
@@ -30,7 +30,7 @@ mod tests {
 	use frame_support::traits::Contains;
 	use minterest_model::MinterestModelData;
 	use minterest_protocol::Error as MinterestProtocolError;
-	use pallet_traits::{PoolsManager, PriceProvider};
+	use pallet_traits::{PoolsManager, PricesManager};
 	use sp_std::cell::RefCell;
 	use test_helper::*;
 
@@ -100,7 +100,7 @@ mod tests {
 
 	pub struct MockPriceSource;
 
-	impl PriceProvider<CurrencyId> for MockPriceSource {
+	impl PricesManager<CurrencyId> for MockPriceSource {
 		fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 			Some(Price::one())
 		}

--- a/pallets/liquidation-pools/src/lib.rs
+++ b/pallets/liquidation-pools/src/lib.rs
@@ -19,7 +19,7 @@ use frame_system::{
 use minterest_primitives::{arithmetic::sum_with_mult_result, Balance, CurrencyId, OffchainErr, Rate};
 use orml_traits::MultiCurrency;
 
-use pallet_traits::{DEXManager, LiquidationPoolsManager, PoolsManager, PriceProvider};
+use pallet_traits::{DEXManager, LiquidationPoolsManager, PoolsManager, PricesManager};
 use sp_runtime::{
 	offchain::storage_lock::{StorageLock, Time},
 	traits::{AccountIdConversion, CheckedDiv, CheckedMul, Zero},
@@ -88,7 +88,7 @@ pub mod module {
 		type LiquidationPoolAccountId: Get<Self::AccountId>;
 
 		/// The price source of currencies
-		type PriceSource: PriceProvider<CurrencyId>;
+		type PriceSource: PricesManager<CurrencyId>;
 
 		/// The basic liquidity pools manager.
 		type LiquidityPoolsManager: PoolsManager<Self::AccountId>;

--- a/pallets/liquidation-pools/src/mock.rs
+++ b/pallets/liquidation-pools/src/mock.rs
@@ -7,7 +7,7 @@ use liquidity_pools::Pool;
 use minterest_primitives::Price;
 pub use minterest_primitives::{currency::CurrencyType::WrappedToken, Balance, CurrencyId, Rate};
 use orml_traits::parameter_type_with_key;
-use pallet_traits::PriceProvider;
+use pallet_traits::PricesManager;
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::testing::TestXt;
@@ -57,7 +57,7 @@ parameter_types! {
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		Some(Price::one())
 	}

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -18,7 +18,7 @@ use minterest_primitives::currency::CurrencyType::UnderlyingAsset;
 use minterest_primitives::{Balance, CurrencyId, Rate};
 pub use module::*;
 use orml_traits::MultiCurrency;
-use pallet_traits::{Borrowing, LiquidityPoolsManager, PoolsManager, PriceProvider};
+use pallet_traits::{Borrowing, LiquidityPoolsManager, PoolsManager, PricesManager};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::{
@@ -80,7 +80,7 @@ pub mod module {
 		type InitialExchangeRate: Get<Rate>;
 
 		/// The price source of currencies
-		type PriceSource: PriceProvider<CurrencyId>;
+		type PriceSource: PricesManager<CurrencyId>;
 
 		#[pallet::constant]
 		/// The Liquidity Pool's module id, keep all assets in Pools.

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -51,7 +51,7 @@ parameter_types! {
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		Some(Price::one())
 	}

--- a/pallets/minterest-model/src/mock.rs
+++ b/pallets/minterest-model/src/mock.rs
@@ -6,7 +6,7 @@ use frame_system::EnsureSignedBy;
 use minterest_primitives::currency::CurrencyType::{UnderlyingAsset, WrappedToken};
 use minterest_primitives::{Balance, CurrencyId, Price, Rate};
 use orml_traits::parameter_type_with_key;
-use pallet_traits::PriceProvider;
+use pallet_traits::PricesManager;
 use sp_core::H256;
 use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::{
@@ -54,7 +54,7 @@ parameter_types! {
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		Some(Price::one())
 	}

--- a/pallets/minterest-protocol/src/lib.rs
+++ b/pallets/minterest-protocol/src/lib.rs
@@ -23,7 +23,7 @@ use minterest_primitives::currency::CurrencyType::UnderlyingAsset;
 use minterest_primitives::{Balance, CurrencyId, Operation, Rate};
 use orml_traits::MultiCurrency;
 use pallet_traits::{
-	Borrowing, ControllerAPI, LiquidationPoolsManager, LiquidityPoolsManager, MinterestModelAPI, MntManager,
+	Borrowing, ControllerManager, LiquidationPoolsManager, LiquidityPoolsManager, MinterestModelAPI, MntManager,
 	PoolsManager, RiskManagerAPI,
 };
 #[cfg(feature = "std")]
@@ -99,7 +99,7 @@ pub mod module {
 		type ProtocolWeightInfo: WeightInfo;
 
 		/// Public API of controller pallet
-		type ControllerAPI: ControllerAPI<Self::AccountId>;
+		type ControllerManager: ControllerManager<Self::AccountId>;
 
 		/// Public API of risk manager pallet
 		type RiskManagerAPI: RiskManagerAPI;
@@ -248,7 +248,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -273,7 +273,7 @@ pub mod module {
 		pub fn redeem(origin: OriginFor<T>, underlying_asset: CurrencyId) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 			let (underlying_amount, wrapped_id, wrapped_amount) =
@@ -303,7 +303,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 			let (_, wrapped_id, wrapped_amount) =
@@ -333,7 +333,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -366,7 +366,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -388,7 +388,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -405,7 +405,7 @@ pub mod module {
 		pub fn repay_all(origin: OriginFor<T>, underlying_asset: CurrencyId) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -429,7 +429,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -453,7 +453,7 @@ pub mod module {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&who), BadOrigin);
 			}
 
@@ -468,7 +468,7 @@ pub mod module {
 		pub fn enable_is_collateral(origin: OriginFor<T>, pool_id: CurrencyId) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&sender), BadOrigin);
 			}
 
@@ -502,7 +502,7 @@ pub mod module {
 		pub fn disable_is_collateral(origin: OriginFor<T>, pool_id: CurrencyId) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
 
-			if T::ControllerAPI::is_whitelist_mode_enabled() {
+			if T::ControllerManager::is_whitelist_mode_enabled() {
 				ensure!(T::WhitelistMembers::contains(&sender), BadOrigin);
 			}
 
@@ -526,9 +526,13 @@ pub mod module {
 				<LiquidityPools<T>>::convert_from_wrapped(wrapped_id, user_balance_wrapped_tokens)?;
 
 			// Check if the user will have enough collateral if he removes one of the collaterals.
-			let (_, shortfall) =
-				T::ControllerAPI::get_hypothetical_account_liquidity(&sender, pool_id, user_balance_disabled_asset, 0)
-					.map_err(|_| Error::<T>::HypotheticalLiquidityCalculationError)?;
+			let (_, shortfall) = T::ControllerManager::get_hypothetical_account_liquidity(
+				&sender,
+				pool_id,
+				user_balance_disabled_asset,
+				0,
+			)
+			.map_err(|_| Error::<T>::HypotheticalLiquidityCalculationError)?;
 			ensure!(shortfall == 0, Error::<T>::IsCollateralCannotBeDisabled);
 
 			<LiquidityPools<T>>::disable_is_collateral_internal(&sender, pool_id);
@@ -560,7 +564,7 @@ impl<T: Config> Pallet<T> {
 			pool_data.multiplier_per_block,
 			pool_data.jump_multiplier_per_block,
 		)?;
-		T::ControllerAPI::create_pool(
+		T::ControllerManager::create_pool(
 			pool_id,
 			pool_data.protocol_interest_factor,
 			pool_data.max_borrow_rate,
@@ -596,14 +600,14 @@ impl<T: Config> Pallet<T> {
 			Error::<T>::NotEnoughLiquidityAvailable
 		);
 
-		T::ControllerAPI::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
+		T::ControllerManager::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
 
 		T::MntManager::update_mnt_supply_index(underlying_asset)?;
 		T::MntManager::distribute_supplier_mnt(underlying_asset, who, false)?;
 
 		// Fail if deposit not allowed
 		ensure!(
-			T::ControllerAPI::is_operation_allowed(underlying_asset, Operation::Deposit),
+			T::ControllerManager::is_operation_allowed(underlying_asset, Operation::Deposit),
 			Error::<T>::OperationPaused
 		);
 
@@ -641,7 +645,7 @@ impl<T: Config> Pallet<T> {
 			liquidity_pools::Error::<T>::PoolNotFound
 		);
 
-		T::ControllerAPI::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
+		T::ControllerManager::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
 
 		let wrapped_id = underlying_asset
 			.wrapped_asset()
@@ -680,10 +684,10 @@ impl<T: Config> Pallet<T> {
 
 		// Fail if redeem not allowed
 		ensure!(
-			T::ControllerAPI::is_operation_allowed(underlying_asset, Operation::Redeem),
+			T::ControllerManager::is_operation_allowed(underlying_asset, Operation::Redeem),
 			Error::<T>::OperationPaused
 		);
-		T::ControllerAPI::redeem_allowed(underlying_asset, &who, wrapped_amount)?;
+		T::ControllerManager::redeem_allowed(underlying_asset, &who, wrapped_amount)?;
 
 		T::MntManager::update_mnt_supply_index(underlying_asset)?;
 		T::MntManager::distribute_supplier_mnt(underlying_asset, who, false)?;
@@ -725,20 +729,20 @@ impl<T: Config> Pallet<T> {
 
 		ensure!(borrow_amount > Balance::zero(), Error::<T>::ZeroBalanceTransaction);
 
-		T::ControllerAPI::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
+		T::ControllerManager::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
 
 		// Fail if borrow not allowed.
 		ensure!(
-			T::ControllerAPI::is_operation_allowed(underlying_asset, Operation::Borrow),
+			T::ControllerManager::is_operation_allowed(underlying_asset, Operation::Borrow),
 			Error::<T>::OperationPaused
 		);
-		T::ControllerAPI::borrow_allowed(underlying_asset, &who, borrow_amount)?;
+		T::ControllerManager::borrow_allowed(underlying_asset, &who, borrow_amount)?;
 
 		T::MntManager::update_mnt_borrow_index(underlying_asset)?;
 		T::MntManager::distribute_borrower_mnt(underlying_asset, who, false)?;
 
 		// Fetch the amount the borrower owes, with accumulated interest.
-		let account_borrows = T::ControllerAPI::borrow_balance_stored(&who, underlying_asset)?;
+		let account_borrows = T::ControllerManager::borrow_balance_stored(&who, underlying_asset)?;
 
 		<LiquidityPools<T>>::update_state_on_borrow(&who, underlying_asset, borrow_amount, account_borrows)?;
 
@@ -775,7 +779,7 @@ impl<T: Config> Pallet<T> {
 			liquidity_pools::Error::<T>::PoolNotFound
 		);
 
-		T::ControllerAPI::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
+		T::ControllerManager::accrue_interest_rate(underlying_asset).map_err(|_| Error::<T>::AccrueInterestFailed)?;
 		repay_amount = Self::do_repay_fresh(who, borrower, underlying_asset, repay_amount, all_assets)?;
 		Ok(repay_amount)
 	}
@@ -799,7 +803,7 @@ impl<T: Config> Pallet<T> {
 
 		// Fail if repay_borrow not allowed
 		ensure!(
-			T::ControllerAPI::is_operation_allowed(underlying_asset, Operation::Repay),
+			T::ControllerManager::is_operation_allowed(underlying_asset, Operation::Repay),
 			Error::<T>::OperationPaused
 		);
 
@@ -807,7 +811,7 @@ impl<T: Config> Pallet<T> {
 		T::MntManager::distribute_borrower_mnt(underlying_asset, borrower, false)?;
 
 		// Fetch the amount the borrower owes, with accumulated interest
-		let account_borrows = T::ControllerAPI::borrow_balance_stored(&borrower, underlying_asset)?;
+		let account_borrows = T::ControllerManager::borrow_balance_stored(&borrower, underlying_asset)?;
 
 		if repay_amount.is_zero() {
 			repay_amount = account_borrows
@@ -857,12 +861,12 @@ impl<T: Config> Pallet<T> {
 
 		// Fail if transfer is not allowed
 		ensure!(
-			T::ControllerAPI::is_operation_allowed(underlying_asset, Operation::Transfer),
+			T::ControllerManager::is_operation_allowed(underlying_asset, Operation::Transfer),
 			Error::<T>::OperationPaused
 		);
 
 		// Fail if transfer_amount is not available for redeem
-		T::ControllerAPI::redeem_allowed(underlying_asset, &who, transfer_amount)?;
+		T::ControllerManager::redeem_allowed(underlying_asset, &who, transfer_amount)?;
 
 		T::MntManager::update_mnt_supply_index(underlying_asset)?;
 		T::MntManager::distribute_supplier_mnt(underlying_asset, who, false)?;
@@ -882,7 +886,7 @@ impl<T: Config> Pallet<T> {
 
 	fn transfer_protocol_interest(pool_id: CurrencyId) {
 		let total_protocol_interest = T::ManagerLiquidityPools::get_pool_total_protocol_interest(pool_id);
-		if total_protocol_interest < T::ControllerAPI::get_protocol_interest_threshold(pool_id) {
+		if total_protocol_interest < T::ControllerManager::get_protocol_interest_threshold(pool_id) {
 			return;
 		}
 

--- a/pallets/minterest-protocol/src/mock.rs
+++ b/pallets/minterest-protocol/src/mock.rs
@@ -10,7 +10,7 @@ use minterest_model::MinterestModelData;
 pub use minterest_primitives::currency::CurrencyType::{UnderlyingAsset, WrappedToken};
 use minterest_primitives::{Balance, CurrencyId, Price, Rate};
 use orml_traits::parameter_type_with_key;
-use pallet_traits::{PriceProvider, RiskManagerAPI};
+use pallet_traits::{PricesManager, RiskManagerAPI};
 use sp_core::H256;
 use sp_runtime::{
 	testing::{Header, TestXt},
@@ -92,7 +92,7 @@ impl RiskManagerAPI for TestRiskManager {
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		Some(Price::one())
 	}

--- a/pallets/mnt-token/rpc/runtime-api/src/lib.rs
+++ b/pallets/mnt-token/rpc/runtime-api/src/lib.rs
@@ -1,4 +1,8 @@
 //! Runtime API definition for mnt-token pallet.
+//! Here we declare the runtime API. It is implemented in the `impl` block in
+//! runtime amalgamator file (the `runtime/src/lib.rs`)
+//!
+//! Corresponding RPC declaration: `pallets/mnt-token/rpc/src/lib.rs`
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // The `too_many_arguments` warning originates from `decl_runtime_apis` macro.
@@ -37,7 +41,7 @@ fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(dese
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime amalgamator file (the `runtime/src/lib.rs`)
 sp_api::decl_runtime_apis! {
-	pub trait MntTokenApi<AccountId>
+	pub trait MntTokenRuntimeApi<AccountId>
 	where
 		AccountId: Codec,
 	{

--- a/pallets/mnt-token/rpc/src/lib.rs
+++ b/pallets/mnt-token/rpc/src/lib.rs
@@ -1,21 +1,39 @@
 //! RPC interface for the mnt-token pallet.
+//!
+//! RPC installation: `rpc/src/lib.rc`
+//!
+//! Corresponding runtime API declaration: `pallets/mnt-token/rpc/run-time/src/lib.rs`
+//! Corresponding runtime API implementation: `runtime/src/lib.rs`
 
 use codec::Codec;
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use minterest_primitives::{CurrencyId, Rate};
-pub use mnt_token_rpc_runtime_api::{MntBalanceInfo, MntTokenApi as MntTokenRuntimeApi};
+pub use mnt_token_rpc_runtime_api::{MntBalanceInfo, MntTokenRuntimeApi};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
 #[rpc]
-pub trait MntTokenApi<BlockHash, AccountId> {
+/// Base trait for RPC interface of mnt-token
+pub trait MntTokenRpcApi<BlockHash, AccountId> {
+	/// Gets MNT accrued but not yet transferred to user
+	///  - `&self` :  Self reference
+	///  - `account_id`: user account id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	/// Return:
+	/// - amount: the MNT accrued but not yet transferred to each user.
 	#[rpc(name = "mntToken_getUnclaimedMntBalance")]
 	fn get_unclaimed_mnt_balance(&self, account_id: AccountId, at: Option<BlockHash>)
 		-> Result<Option<MntBalanceInfo>>;
 
+	/// Return MNT Borrow Rate and MNT Supply Rate values per block for current pool.
+	///  - `&self` :  Self reference
+	///  - `pool_id`: current pool id.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	/// Return:
+	/// - (borrow_rate, supply_rate): MNT Borrow Rate and MNT Supply Rate values
 	#[rpc(name = "mntToken_getMntBorrowAndSupplyRates")]
 	fn get_mnt_borrow_and_supply_rates(
 		&self,
@@ -24,14 +42,14 @@ pub trait MntTokenApi<BlockHash, AccountId> {
 	) -> Result<Option<(Rate, Rate)>>;
 }
 
-/// A struct that implements the [`MntTokenApi`].
-pub struct MntToken<C, B> {
+/// A struct that implements the `MntTokenRpcApi`.
+pub struct MntTokenRpcImpl<C, B> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<B>,
 }
 
-impl<C, B> MntToken<C, B> {
-	/// Create new `MntToken` with the given reference to the client.
+impl<C, B> MntTokenRpcImpl<C, B> {
+	/// Create new `MntTokenRpcImpl` with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self {
 			client,
@@ -52,7 +70,8 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block, AccountId> MntTokenApi<<Block as BlockT>::Hash, AccountId> for MntToken<C, Block>
+/// Implementation of 'MntTokenRpcApi'
+impl<C, Block, AccountId> MntTokenRpcApi<<Block as BlockT>::Hash, AccountId> for MntTokenRpcImpl<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/pallets/mnt-token/src/lib.rs
+++ b/pallets/mnt-token/src/lib.rs
@@ -10,7 +10,7 @@ use frame_system::pallet_prelude::*;
 use minterest_primitives::{currency::MNT, Balance, CurrencyId, Price, Rate};
 pub use module::*;
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerManager, LiquidityPoolsManager, MntManager, PoolsManager, PriceProvider};
+use pallet_traits::{ControllerManager, LiquidityPoolsManager, MntManager, PoolsManager, PricesManager};
 use sp_runtime::{
 	traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero},
 	DispatchResult, FixedPointNumber, FixedU128,
@@ -88,7 +88,7 @@ pub mod module {
 		type UpdateOrigin: EnsureOrigin<Self::Origin>;
 
 		/// The price source of currencies
-		type PriceSource: PriceProvider<CurrencyId>;
+		type PriceSource: PricesManager<CurrencyId>;
 
 		/// The `MultiCurrency` implementation for wrapped.
 		type MultiCurrency: MultiCurrency<Self::AccountId, Balance = Balance, CurrencyId = CurrencyId>;

--- a/pallets/mnt-token/src/lib.rs
+++ b/pallets/mnt-token/src/lib.rs
@@ -10,7 +10,7 @@ use frame_system::pallet_prelude::*;
 use minterest_primitives::{currency::MNT, Balance, CurrencyId, Price, Rate};
 pub use module::*;
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerAPI, LiquidityPoolsManager, MntManager, PoolsManager, PriceProvider};
+use pallet_traits::{ControllerManager, LiquidityPoolsManager, MntManager, PoolsManager, PriceProvider};
 use sp_runtime::{
 	traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero},
 	DispatchResult, FixedPointNumber, FixedU128,
@@ -94,7 +94,7 @@ pub mod module {
 		type MultiCurrency: MultiCurrency<Self::AccountId, Balance = Balance, CurrencyId = CurrencyId>;
 
 		/// Public API of controller pallet
-		type ControllerAPI: ControllerAPI<Self::AccountId>;
+		type ControllerManager: ControllerManager<Self::AccountId>;
 
 		#[pallet::constant]
 		/// The Mnt-token's account id, keep assets that should be distributed to users
@@ -581,7 +581,7 @@ impl<T: Config> MntManager<T::AccountId> for Pallet<T> {
 			return Ok(Balance::zero());
 		}
 
-		let borrow_balance = T::ControllerAPI::borrow_balance_stored(&borrower, underlying_id)?;
+		let borrow_balance = T::ControllerManager::borrow_balance_stored(&borrower, underlying_id)?;
 		let pool_borrow_index = T::LiquidityPoolsManager::get_pool_borrow_index(underlying_id);
 		let borrower_amount = Price::from_inner(borrow_balance)
 			.checked_div(&pool_borrow_index)

--- a/pallets/mnt-token/src/mock.rs
+++ b/pallets/mnt-token/src/mock.rs
@@ -7,7 +7,7 @@ use liquidity_pools::{Pool, PoolUserData};
 pub use minterest_primitives::currency::CurrencyType::{UnderlyingAsset, WrappedToken};
 use minterest_primitives::{Balance, CurrencyId, Price, Rate};
 use orml_traits::parameter_type_with_key;
-use pallet_traits::PriceProvider;
+use pallet_traits::PricesManager;
 use sp_runtime::{
 	testing::{Header, H256},
 	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup, Zero},
@@ -67,7 +67,7 @@ ord_parameter_types! {
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(currency_id: CurrencyId) -> Option<Price> {
 		match currency_id {
 			DOT => return Some(Price::saturating_from_rational(5, 10)), // 0.5 USD

--- a/pallets/prices/rpc/runtime-api/src/lib.rs
+++ b/pallets/prices/rpc/runtime-api/src/lib.rs
@@ -14,7 +14,7 @@ use minterest_primitives::{CurrencyId, Price};
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
-	pub trait PricesApi
+	pub trait PricesRuntimeApi
 	{
 		fn  get_current_price(currency_id: CurrencyId) -> Option<Price>;
 		fn  get_all_locked_prices() -> Vec<(CurrencyId, Option<Price>)>;

--- a/pallets/prices/rpc/src/lib.rs
+++ b/pallets/prices/rpc/src/lib.rs
@@ -8,7 +8,7 @@
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use minterest_primitives::{CurrencyId, Price};
-pub use prices_rpc_runtime_api::PricesApi as PricesRuntimeApi;
+pub use prices_rpc_runtime_api::PricesRuntimeApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
@@ -16,14 +16,17 @@ use std::sync::Arc;
 
 #[rpc]
 /// Base trait for RPC interface of prices
-pub trait PricesApi<BlockHash> {
+pub trait PricesRpcApi<BlockHash> {
 	/// This function returns a price for a currency.
 	/// If currency price has been locked, locked value will be returned.
 	/// Otherwise the value from Oracle will be returned
 	///
 	///  - `&self` :  Self reference
-	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
 	///  - `currency_id`: currency type.
+	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
+	///
+	/// Return:
+	/// - price: price for currency
 	///
 	///  # Example:
 	/// ``` ignore
@@ -40,6 +43,9 @@ pub trait PricesApi<BlockHash> {
 	///  - `&self` :  Self reference
 	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
 	///
+	/// Return:
+	/// - Vec<(currency_id, price)>: vector of (id, price) pairs for all locked currencies
+	///
 	/// # Example:
 	/// ``` ignore
 	/// curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d '{"jsonrpc":"2.0",
@@ -53,6 +59,9 @@ pub trait PricesApi<BlockHash> {
 	///  - `&self` :  Self reference
 	///  - `at` : Needed for runtime API use. Runtime API must always be called at a specific block.
 	///
+	/// Return:
+	/// - Vec<(currency_id, price)>: vector of (id, price) pairs for all currencies
+	///
 	/// # Example:
 	/// ``` ignore
 	/// curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d '{"jsonrpc":"2.0",
@@ -62,14 +71,14 @@ pub trait PricesApi<BlockHash> {
 	fn get_all_freshest_prices(&self, at: Option<BlockHash>) -> Result<Vec<(CurrencyId, Option<Price>)>>;
 }
 
-/// Struct that implement 'PricesApi'.
-pub struct Prices<C, M> {
+/// Struct that implement 'PricesRpcApi'.
+pub struct PricesRpcImpl<C, M> {
 	client: Arc<C>,
 	_marker: std::marker::PhantomData<M>,
 }
 
-impl<C, M> Prices<C, M> {
-	/// Create new `Prices` instance with the given reference to the client.
+impl<C, M> PricesRpcImpl<C, M> {
+	/// Create new `PricesRpcImpl` instance with the given reference to the client.
 	pub fn new(client: Arc<C>) -> Self {
 		Self {
 			client,
@@ -78,7 +87,7 @@ impl<C, M> Prices<C, M> {
 	}
 }
 
-// Error enum
+/// Error enum
 pub enum Error {
 	RuntimeError,
 }
@@ -91,8 +100,8 @@ impl From<Error> for i64 {
 	}
 }
 
-/// Implementation of 'PricesApi'
-impl<C, Block> PricesApi<<Block as BlockT>::Hash> for Prices<C, Block>
+/// Implementation of 'PricesRpcApi'
+impl<C, Block> PricesRpcApi<<Block as BlockT>::Hash> for PricesRpcImpl<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,

--- a/pallets/prices/src/lib.rs
+++ b/pallets/prices/src/lib.rs
@@ -14,7 +14,7 @@
 use frame_support::{pallet_prelude::*, transactional};
 use minterest_primitives::{currency::CurrencyType::UnderlyingAsset, CurrencyId, Price};
 use orml_traits::{DataFeeder, DataProvider};
-use pallet_traits::PriceProvider;
+use pallet_traits::PricesManager;
 use sp_std::vec::Vec;
 
 pub use module::*;
@@ -116,7 +116,7 @@ pub mod module {
 				Error::<T>::NotValidUnderlyingAssetId
 			);
 
-			<Pallet<T> as PriceProvider<CurrencyId>>::lock_price(currency_id);
+			<Pallet<T> as PricesManager<CurrencyId>>::lock_price(currency_id);
 			Ok(().into())
 		}
 
@@ -135,13 +135,13 @@ pub mod module {
 				Error::<T>::NotValidUnderlyingAssetId
 			);
 
-			<Pallet<T> as PriceProvider<CurrencyId>>::unlock_price(currency_id);
+			<Pallet<T> as PricesManager<CurrencyId>>::unlock_price(currency_id);
 			Ok(().into())
 		}
 	}
 }
 
-impl<T: Config> PriceProvider<CurrencyId> for Pallet<T> {
+impl<T: Config> PricesManager<CurrencyId> for Pallet<T> {
 	/// Get price underlying token in USD.
 	fn get_underlying_price(currency_id: CurrencyId) -> Option<Price> {
 		// if locked price exists, return it, otherwise return latest price from oracle:

--- a/pallets/risk-manager/src/lib.rs
+++ b/pallets/risk-manager/src/lib.rs
@@ -24,7 +24,9 @@ use frame_system::{
 };
 use minterest_primitives::{Balance, CurrencyId, OffchainErr, Rate};
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerAPI, LiquidationPoolsManager, MntManager, PoolsManager, PriceProvider, RiskManagerAPI};
+use pallet_traits::{
+	ControllerManager, LiquidationPoolsManager, MntManager, PoolsManager, PriceProvider, RiskManagerAPI,
+};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::{
@@ -97,7 +99,7 @@ pub mod module {
 		type LiquidityPoolsManager: PoolsManager<Self::AccountId>;
 
 		/// Public API of controller pallet
-		type ControllerAPI: ControllerAPI<Self::AccountId>;
+		type ControllerManager: ControllerManager<Self::AccountId>;
 
 		/// Provides MNT token distribution functionality.
 		type MntManager: MntManager<Self::AccountId>;
@@ -400,7 +402,7 @@ impl<T: Config> Pallet<T> {
 
 		for (pos, currency_id) in underlying_assets.iter().enumerate() {
 			debug::info!("RiskManager starts processing loans for {:?}", currency_id);
-			<T as module::Config>::ControllerAPI::accrue_interest_rate(*currency_id)
+			<T as module::Config>::ControllerManager::accrue_interest_rate(*currency_id)
 				.map_err(|_| OffchainErr::CheckFail)?;
 			let pool_members =
 				<LiquidityPools<T>>::get_pool_members_with_loans(*currency_id).map_err(|_| OffchainErr::CheckFail)?;
@@ -411,7 +413,7 @@ impl<T: Config> Pallet<T> {
 
 				// Checks if the liquidation should be allowed to occur.
 				if user_has_collateral {
-					let (_, shortfall) = <T as module::Config>::ControllerAPI::get_hypothetical_account_liquidity(
+					let (_, shortfall) = <T as module::Config>::ControllerManager::get_hypothetical_account_liquidity(
 						&member,
 						*currency_id,
 						0,
@@ -490,7 +492,7 @@ impl<T: Config> Pallet<T> {
 	/// - `liquidated_pool_id`: the CurrencyId of the pool with loan, for which automatic
 	/// liquidation is performed.
 	pub fn liquidate_unsafe_loan(borrower: T::AccountId, liquidated_pool_id: CurrencyId) -> DispatchResult {
-		<T as module::Config>::ControllerAPI::accrue_interest_rate(liquidated_pool_id)?;
+		<T as module::Config>::ControllerManager::accrue_interest_rate(liquidated_pool_id)?;
 
 		// Read prices price for borrowed pool.
 		let price_borrowed =
@@ -499,7 +501,7 @@ impl<T: Config> Pallet<T> {
 		// Get borrower borrow balance and calculate total_repay_amount (in USD):
 		// total_repay_amount = borrow_balance * price_borrowed
 		let borrow_balance =
-			<T as module::Config>::ControllerAPI::borrow_balance_stored(&borrower, liquidated_pool_id)?;
+			<T as module::Config>::ControllerManager::borrow_balance_stored(&borrower, liquidated_pool_id)?;
 		let total_repay_amount = Rate::from_inner(borrow_balance)
 			.checked_mul(&price_borrowed)
 			.map(|x| x.into_inner())
@@ -558,7 +560,7 @@ impl<T: Config> Pallet<T> {
 
 		for collateral_pool_id in collateral_pools.into_iter() {
 			if !seize_amount.is_zero() {
-				<T as module::Config>::ControllerAPI::accrue_interest_rate(collateral_pool_id)?;
+				<T as module::Config>::ControllerManager::accrue_interest_rate(collateral_pool_id)?;
 
 				let wrapped_id = collateral_pool_id
 					.wrapped_asset()

--- a/pallets/risk-manager/src/lib.rs
+++ b/pallets/risk-manager/src/lib.rs
@@ -25,7 +25,7 @@ use frame_system::{
 use minterest_primitives::{Balance, CurrencyId, OffchainErr, Rate};
 use orml_traits::MultiCurrency;
 use pallet_traits::{
-	ControllerManager, LiquidationPoolsManager, MntManager, PoolsManager, PriceProvider, RiskManagerAPI,
+	ControllerManager, LiquidationPoolsManager, MntManager, PoolsManager, PricesManager, RiskManagerAPI,
 };
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/pallets/risk-manager/src/mock.rs
+++ b/pallets/risk-manager/src/mock.rs
@@ -109,7 +109,7 @@ mock_impl_balances_config!(Test);
 
 pub struct MockPriceSource;
 
-impl PriceProvider<CurrencyId> for MockPriceSource {
+impl PricesManager<CurrencyId> for MockPriceSource {
 	fn get_underlying_price(_currency_id: CurrencyId) -> Option<Price> {
 		Some(Price::one())
 	}

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -58,16 +58,26 @@ pub trait LiquidationPoolsManager<AccountId> {
 	/// Return liquidity balance of `pool_id`.
 	fn get_pool_available_liquidity(pool_id: CurrencyId) -> Balance;
 
+	/// This is a part of a pool creation flow
+	/// Checks parameters validity and creates storage records for LiquidationPoolsData
 	fn create_pool(currency_id: CurrencyId, deviation_threshold: Rate, balance_ratio: Rate) -> DispatchResult;
 }
 
-pub trait PriceProvider<CurrencyId> {
+/// An abstraction of prices basic functionalities.
+pub trait PricesManager<CurrencyId> {
+	/// Get price underlying token in USD.
 	fn get_underlying_price(currency_id: CurrencyId) -> Option<Price>;
+
+	/// Locks price when get valid price from source.
 	fn lock_price(currency_id: CurrencyId);
+
+	/// Unlocks price when get valid price from source.
 	fn unlock_price(currency_id: CurrencyId);
 }
 
+/// An abstraction of DEXs basic functionalities.
 pub trait DEXManager<AccountId, CurrencyId, Balance> {
+	//TODO: Add function description
 	fn swap_with_exact_supply(
 		who: &AccountId,
 		target_currency_id: CurrencyId,
@@ -76,6 +86,7 @@ pub trait DEXManager<AccountId, CurrencyId, Balance> {
 		min_target_amount: Balance,
 	) -> Result<Balance, DispatchError>;
 
+	//TODO: Add function description
 	fn swap_with_exact_target(
 		who: &AccountId,
 		supply_currency_id: CurrencyId,
@@ -85,6 +96,7 @@ pub trait DEXManager<AccountId, CurrencyId, Balance> {
 	) -> Result<Balance, DispatchError>;
 }
 
+/// An abstraction of controller basic functionalities.
 pub trait ControllerManager<AccountId> {
 	/// This is a part of a pool creation flow
 	/// Creates storage records for ControllerParams and PauseKeepers
@@ -173,6 +185,7 @@ pub trait MntManager<AccountId> {
 	fn get_mnt_borrow_and_supply_rates(pool_id: CurrencyId) -> Result<(Price, Price), DispatchError>;
 }
 
+/// An abstraction of risk-manager basic functionalities.
 pub trait RiskManagerAPI {
 	/// This is a part of a pool creation flow
 	/// Creates storage records for RiskManagerParams
@@ -185,6 +198,7 @@ pub trait RiskManagerAPI {
 	) -> DispatchResult;
 }
 
+/// An abstraction of minterest-model basic functionalities.
 pub trait MinterestModelAPI {
 	/// This is a part of a pool creation flow
 	/// Checks parameters validity and creates storage records for MinterestModelParams

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -85,7 +85,7 @@ pub trait DEXManager<AccountId, CurrencyId, Balance> {
 	) -> Result<Balance, DispatchError>;
 }
 
-pub trait ControllerAPI<AccountId> {
+pub trait ControllerManager<AccountId> {
 	/// This is a part of a pool creation flow
 	/// Creates storage records for ControllerParams and PauseKeepers
 	/// All operations are unpaused after this function call

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -34,10 +34,10 @@ where
 	P: TransactionPool + 'static,
 {
 	use controller_rpc::{ControllerRpcApi, ControllerRpcImpl};
-	use mnt_token_rpc::{MntToken, MntTokenApi};
+	use mnt_token_rpc::{MntTokenRpcApi, MntTokenRpcImpl};
 	use orml_oracle_rpc::{Oracle, OracleApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
-	use prices_rpc::{Prices, PricesApi};
+	use prices_rpc::{PricesRpcApi, PricesRpcImpl};
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
@@ -61,9 +61,9 @@ where
 
 	io.extend_with(OracleApi::to_delegate(Oracle::new(client.clone())));
 
-	io.extend_with(MntTokenApi::to_delegate(MntToken::new(client.clone())));
+	io.extend_with(MntTokenRpcApi::to_delegate(MntTokenRpcImpl::new(client.clone())));
 
-	io.extend_with(PricesApi::to_delegate(Prices::new(client)));
+	io.extend_with(PricesRpcApi::to_delegate(PricesRpcImpl::new(client)));
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed
 	// to call into the runtime.

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -33,7 +33,7 @@ where
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
 {
-	use controller_rpc::{Controller, ControllerApi};
+	use controller_rpc::{ControllerRpcApi, ControllerRpcImpl};
 	use mnt_token_rpc::{MntToken, MntTokenApi};
 	use orml_oracle_rpc::{Oracle, OracleApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
@@ -57,7 +57,7 @@ where
 		client.clone(),
 	)));
 
-	io.extend_with(ControllerApi::to_delegate(Controller::new(client.clone())));
+	io.extend_with(ControllerRpcApi::to_delegate(ControllerRpcImpl::new(client.clone())));
 
 	io.extend_with(OracleApi::to_delegate(Oracle::new(client.clone())));
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub use sp_runtime::{Perbill, Permill, Perquintill};
 pub use constants::{currency::*, time::*, *};
 use frame_support::traits::Contains;
 use frame_system::{EnsureOneOf, EnsureRoot};
-use pallet_traits::PriceProvider;
+use pallet_traits::PricesManager;
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
@@ -818,7 +818,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl mnt_token_rpc_runtime_api::MntTokenApi<Block, AccountId> for Runtime {
+	impl mnt_token_rpc_runtime_api::MntTokenRuntimeApi<Block, AccountId> for Runtime {
 		fn get_unclaimed_mnt_balance(account_id: AccountId) -> Option<MntBalanceInfo> {
 				Some(MntBalanceInfo{amount: MntToken::get_unclaimed_mnt_balance(&account_id).ok()?})
 		}
@@ -849,7 +849,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl prices_rpc_runtime_api::PricesApi<Block> for Runtime {
+	impl prices_rpc_runtime_api::PricesRuntimeApi<Block> for Runtime {
 		fn  get_current_price(currency_id: CurrencyId) -> Option<Price> {
 			Prices::get_underlying_price(currency_id)
 		}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,7 +31,7 @@ use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::{create_median_value_data_provider, parameter_type_with_key, DataFeeder, DataProviderExtended};
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
-use pallet_traits::{ControllerAPI, MntManager, PoolsManager};
+use pallet_traits::{ControllerManager, MntManager, PoolsManager};
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -363,7 +363,7 @@ impl minterest_protocol::Config for Runtime {
 	type MntManager = MntToken;
 	type WhitelistMembers = WhitelistCouncilProvider;
 	type ProtocolWeightInfo = weights::minterest_protocol::WeightInfo<Runtime>;
-	type ControllerAPI = Controller;
+	type ControllerManager = Controller;
 	type RiskManagerAPI = RiskManager;
 	type MinterestModelAPI = MinterestModel;
 	type CreatePoolOrigin = EnsureRootOrHalfMinterestCouncil;
@@ -476,7 +476,7 @@ impl risk_manager::Config for Runtime {
 	type MntManager = MntToken;
 	type RiskManagerUpdateOrigin = EnsureRootOrHalfMinterestCouncil;
 	type RiskManagerWeightInfo = weights::risk_manager::WeightInfo<Runtime>;
-	type ControllerAPI = Controller;
+	type ControllerManager = Controller;
 	type OffchainWorkerMaxDurationMs = RiskManagerWorkerMaxDurationMs;
 }
 
@@ -491,7 +491,7 @@ impl mnt_token::Config for Runtime {
 	type UpdateOrigin = EnsureRootOrTwoThirdsMinterestCouncil;
 	type LiquidityPoolsManager = LiquidityPools;
 	type MultiCurrency = Currencies;
-	type ControllerAPI = Controller;
+	type ControllerManager = Controller;
 	type MntTokenAccountId = MntTokenAccountId;
 	type MntTokenWeightInfo = weights::mnt_token::WeightInfo<Runtime>;
 	type SpeedRefreshPeriod = RefreshSpeedPeriod;
@@ -774,7 +774,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl controller_rpc_runtime_api::ControllerApi<Block, AccountId> for Runtime {
+	impl controller_rpc_runtime_api::ControllerRuntimeApi<Block, AccountId> for Runtime {
 		fn liquidity_pool_state(pool_id: CurrencyId) -> Option<PoolState> {
 			let exchange_rate = Controller::get_liquidity_pool_exchange_rate(pool_id)?;
 			let (borrow_rate, supply_rate) = Controller::get_liquidity_pool_borrow_and_supply_rates(pool_id)?;

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use controller::{ControllerData, PauseKeeper};
 use controller_rpc_runtime_api::{
-	runtime_decl_for_ControllerApi::ControllerApi, BalanceInfo, HypotheticalLiquidityData, PoolState,
+	runtime_decl_for_ControllerRuntimeApi::ControllerRuntimeApi, BalanceInfo, HypotheticalLiquidityData, PoolState,
 	UserPoolBalanceData,
 };
 use frame_support::{
@@ -18,7 +18,7 @@ use minterest_model::MinterestModelData;
 use minterest_primitives::{CurrencyId, Operation, Price};
 use mnt_token_rpc_runtime_api::runtime_decl_for_MntTokenApi::MntTokenApi;
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerAPI, DEXManager, LiquidationPoolsManager, PoolsManager, PriceProvider};
+use pallet_traits::{ControllerManager, DEXManager, LiquidationPoolsManager, PoolsManager, PriceProvider};
 use prices_rpc_runtime_api::runtime_decl_for_PricesApi::PricesApi;
 use risk_manager::RiskManagerData;
 use sp_runtime::{traits::Zero, DispatchResult, FixedPointNumber};
@@ -409,29 +409,29 @@ fn dex_balance(pool_id: CurrencyId) -> Balance {
 }
 
 fn liquidity_pool_state_rpc(currency_id: CurrencyId) -> Option<PoolState> {
-	<Runtime as ControllerApi<Block, AccountId>>::liquidity_pool_state(currency_id)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::liquidity_pool_state(currency_id)
 }
 
 fn get_total_supply_and_borrowed_usd_balance_rpc(account_id: AccountId) -> Option<UserPoolBalanceData> {
-	<Runtime as ControllerApi<Block, AccountId>>::get_total_supply_and_borrowed_usd_balance(account_id)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::get_total_supply_and_borrowed_usd_balance(account_id)
 }
 
 fn get_hypothetical_account_liquidity_rpc(account_id: AccountId) -> Option<HypotheticalLiquidityData> {
-	<Runtime as ControllerApi<Block, AccountId>>::get_hypothetical_account_liquidity(account_id)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::get_hypothetical_account_liquidity(account_id)
 }
 
 fn is_admin_rpc(caller: AccountId) -> Option<bool> {
-	<Runtime as ControllerApi<Block, AccountId>>::is_admin(caller)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::is_admin(caller)
 }
 
 fn get_user_total_collateral_rpc(account_id: AccountId) -> Balance {
-	<Runtime as ControllerApi<Block, AccountId>>::get_user_total_collateral(account_id)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::get_user_total_collateral(account_id)
 		.unwrap()
 		.amount
 }
 
 fn get_user_borrow_per_asset_rpc(account_id: AccountId, underlying_asset_id: CurrencyId) -> Option<BalanceInfo> {
-	<Runtime as ControllerApi<Block, AccountId>>::get_user_borrow_per_asset(account_id, underlying_asset_id)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::get_user_borrow_per_asset(account_id, underlying_asset_id)
 }
 
 fn get_unclaimed_mnt_balance_rpc(account_id: AccountId) -> Balance {
@@ -441,7 +441,7 @@ fn get_unclaimed_mnt_balance_rpc(account_id: AccountId) -> Balance {
 }
 
 fn pool_exists_rpc(underlying_asset_id: CurrencyId) -> bool {
-	<Runtime as ControllerApi<Block, AccountId>>::pool_exists(underlying_asset_id)
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::pool_exists(underlying_asset_id)
 }
 
 fn dollars(amount: u128) -> u128 {

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -16,10 +16,10 @@ use liquidation_pools::{LiquidationPoolData, Sales};
 use liquidity_pools::{Pool, PoolUserData};
 use minterest_model::MinterestModelData;
 use minterest_primitives::{CurrencyId, Operation, Price};
-use mnt_token_rpc_runtime_api::runtime_decl_for_MntTokenApi::MntTokenApi;
+use mnt_token_rpc_runtime_api::runtime_decl_for_MntTokenRuntimeApi::MntTokenRuntimeApi;
 use orml_traits::MultiCurrency;
-use pallet_traits::{ControllerManager, DEXManager, LiquidationPoolsManager, PoolsManager, PriceProvider};
-use prices_rpc_runtime_api::runtime_decl_for_PricesApi::PricesApi;
+use pallet_traits::{ControllerManager, DEXManager, LiquidationPoolsManager, PoolsManager, PricesManager};
+use prices_rpc_runtime_api::runtime_decl_for_PricesRuntimeApi::PricesRuntimeApi;
 use risk_manager::RiskManagerData;
 use sp_runtime::{traits::Zero, DispatchResult, FixedPointNumber};
 use test_helper::{BTC, DOT, ETH, KSM, MDOT, METH, MNT};
@@ -435,7 +435,7 @@ fn get_user_borrow_per_asset_rpc(account_id: AccountId, underlying_asset_id: Cur
 }
 
 fn get_unclaimed_mnt_balance_rpc(account_id: AccountId) -> Balance {
-	<Runtime as MntTokenApi<Block, AccountId>>::get_unclaimed_mnt_balance(account_id)
+	<Runtime as MntTokenRuntimeApi<Block, AccountId>>::get_unclaimed_mnt_balance(account_id)
 		.unwrap()
 		.amount
 }
@@ -483,11 +483,11 @@ fn set_oracle_price_for_all_pools(price: u128) -> DispatchResult {
 }
 
 fn get_all_locked_prices() -> Vec<(CurrencyId, Option<Price>)> {
-	<Runtime as PricesApi<Block>>::get_all_locked_prices()
+	<Runtime as PricesRuntimeApi<Block>>::get_all_locked_prices()
 }
 
 fn get_all_freshest_prices() -> Vec<(CurrencyId, Option<Price>)> {
-	<Runtime as PricesApi<Block>>::get_all_freshest_prices()
+	<Runtime as PricesRuntimeApi<Block>>::get_all_freshest_prices()
 }
 
 fn unlock_price(currency_id: CurrencyId) -> DispatchResultWithPostInfo {
@@ -495,7 +495,7 @@ fn unlock_price(currency_id: CurrencyId) -> DispatchResultWithPostInfo {
 }
 
 fn get_mnt_borrow_and_supply_rates(pool_id: CurrencyId) -> (Rate, Rate) {
-	<Runtime as MntTokenApi<Block, AccountId>>::get_mnt_borrow_and_supply_rates(pool_id).unwrap()
+	<Runtime as MntTokenRuntimeApi<Block, AccountId>>::get_mnt_borrow_and_supply_rates(pool_id).unwrap()
 }
 
 pub fn run_to_block(n: u32) {

--- a/test-helper/src/lib.rs
+++ b/test-helper/src/lib.rs
@@ -208,7 +208,7 @@ macro_rules! mock_impl_minterest_protocol_config {
 			type MntManager = mnt_token::Module<$target>;
 			type WhitelistMembers = WhitelistMembers;
 			type ProtocolWeightInfo = ();
-			type ControllerAPI = controller::Module<$target>;
+			type ControllerManager = controller::Module<$target>;
 			type RiskManagerAPI = TestRiskManager;
 			type MinterestModelAPI = TestMinterestModel;
 			type CreatePoolOrigin = EnsureSignedBy<$acc, AccountId>;
@@ -232,7 +232,7 @@ macro_rules! mock_impl_risk_manager_config {
 			type MntManager = mnt_token::Module<$target>;
 			type RiskManagerUpdateOrigin = EnsureSignedBy<$acc, AccountId>;
 			type RiskManagerWeightInfo = ();
-			type ControllerAPI = controller::Module<$target>;
+			type ControllerManager = controller::Module<$target>;
 			type OffchainWorkerMaxDurationMs = MaxDurationMs;
 		}
 	};
@@ -251,7 +251,7 @@ macro_rules! mock_impl_mnt_token_config {
 			type UpdateOrigin = EnsureSignedBy<$acc, AccountId>;
 			type LiquidityPoolsManager = liquidity_pools::Module<$target>;
 			type MultiCurrency = orml_currencies::Module<$target>;
-			type ControllerAPI = controller::Module<$target>;
+			type ControllerManager = controller::Module<$target>;
 			type MntTokenAccountId = MntTokenAccountId;
 			type SpeedRefreshPeriod = SpeedRefreshPeriod;
 			type MntTokenWeightInfo = ();


### PR DESCRIPTION
**Description:**
Renamed traits for pallet to meet the convention

**List of changes**

Controller:
* runtime_api ControllerApi	->	ControllerRuntimeApi
* rpc ControllerApi 		->	ControllerRpcApi
* rpc Controller		->	ControllerRpcImpl
* traits ControllerAPI		->	ControllerManager

Prices:
* runtime_api PricesApi		->	PricesRuntimeApi
* rpc PricesApi 		->	PricesRpcApi
* rpc Prices			->	PricesRpcImpl
* traits PriceProvider		->	PricesManager

MntToken:
* runtime_api MntTokenApi	->	MntTokenRuntimeApi
* rpc MntTokenApi 		->	MntTokenRpcApi
* rpc MntToken			->	MntTokenRpcImpl