### PR TITLE
[MIN-339] Implement getUserUnderlyingBalancePerAsset RPC

### DIFF
--- a/pallets/controller/rpc/runtime-api/src/lib.rs
+++ b/pallets/controller/rpc/runtime-api/src/lib.rs
@@ -89,6 +89,11 @@ sp_api::decl_runtime_apis! {
 			underlying_asset_id: CurrencyId,
 		) -> Option<BalanceInfo>;
 
+		fn get_user_underlying_balance_per_asset(
+			account_id: AccountId,
+			pool_id: CurrencyId,
+		) -> Option<BalanceInfo>;
+
 		fn pool_exists(underlying_asset_id: CurrencyId) -> bool;
 	}
 }

--- a/pallets/controller/rpc/src/lib.rs
+++ b/pallets/controller/rpc/src/lib.rs
@@ -119,6 +119,15 @@ pub trait ControllerRpcApi<BlockHash, AccountId> {
 		at: Option<BlockHash>,
 	) -> Result<Option<BalanceInfo>>;
 
+	/// Returns user underlying asset balance for the pool
+	#[rpc(name = "controller_getUserUnderlyingBalancePerAsset")]
+	fn get_user_underlying_balance_per_asset(
+		&self,
+		account_id: AccountId,
+		pool_id: CurrencyId,
+		at: Option<BlockHash>,
+	) -> Result<Option<BalanceInfo>>;
+
 	/// Checks whether the pool is created in storage.
 	///
 	///  - `&self` :  Self reference
@@ -283,6 +292,24 @@ where
 			.map_err(|e| RpcError {
 				code: ErrorCode::ServerError(Error::RuntimeError.into()),
 				message: "Unable to get total user borrow balance.".into(),
+				data: Some(format!("{:?}", e).into()),
+			})
+	}
+
+	fn get_user_underlying_balance_per_asset(
+		&self,
+		account_id: AccountId,
+		pool_id: CurrencyId,
+		at: Option<<Block as BlockT>::Hash>,
+	) -> Result<Option<BalanceInfo>> {
+		let api = self.client.runtime_api();
+		let at = BlockId::hash(at.unwrap_or_else(||
+			// If the block hash is not supplied assume the best block.
+			self.client.info().best_hash));
+		api.get_user_underlying_balance_per_asset(&at, account_id, pool_id)
+			.map_err(|e| RpcError {
+				code: ErrorCode::ServerError(Error::RuntimeError.into()),
+				message: "Unable to get user underlying balance.".into(),
 				data: Some(format!("{:?}", e).into()),
 			})
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -837,6 +837,10 @@ impl_runtime_apis! {
 				Some(BalanceInfo{amount: Controller::get_user_borrow_per_asset(&account_id, underlying_asset_id).ok()?})
 		}
 
+		fn get_user_underlying_balance_per_asset(account_id: AccountId, pool_id: CurrencyId) -> Option<BalanceInfo> {
+				Some(BalanceInfo{amount: Controller::get_user_underlying_balance_per_asset(&account_id, pool_id).ok()?})
+		}
+
 		fn pool_exists(underlying_asset_id: CurrencyId) -> bool {
 			LiquidityPools::pool_exists(&underlying_asset_id)
 		}

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -442,6 +442,10 @@ fn get_user_borrow_per_asset_rpc(account_id: AccountId, underlying_asset_id: Cur
 	<Runtime as ControllerRuntimeApi<Block, AccountId>>::get_user_borrow_per_asset(account_id, underlying_asset_id)
 }
 
+fn get_user_underlying_balance_per_asset_rpc(account_id: AccountId, pool_id: CurrencyId) -> Option<BalanceInfo> {
+	<Runtime as ControllerRuntimeApi<Block, AccountId>>::get_user_underlying_balance_per_asset(account_id, pool_id)
+}
+
 fn get_unclaimed_mnt_balance_rpc(account_id: AccountId) -> Balance {
 	<Runtime as MntTokenRuntimeApi<Block, AccountId>>::get_unclaimed_mnt_balance(account_id)
 		.unwrap()

--- a/runtime/src/tests/rpc_tests.rs
+++ b/runtime/src/tests/rpc_tests.rs
@@ -803,6 +803,19 @@ fn get_user_total_collateral_rpc_should_work() {
 		})
 }
 
+/// This test checks get_user_underlying_balance_per_asset RPC.
+///
+/// Test scenario:
+/// - Alice deposits 90 to DOT pool
+/// - Alice deposits 90 to ETH pool
+/// - Balance converted to underlying is equal to deposited amount for both pools
+/// - Alice borrows 40 from ETH pool
+/// - Balance converted to underlying is still equal to deposited amount for both pools
+/// - Jump to block #100
+/// - Balance converted to underlying has increased for ETH pool
+/// - Alice repays all
+/// - Alice redeems money from protocol
+/// - Alice ETH balance increased by a value that was previously returned by RPC
 #[test]
 fn test_get_user_underlying_balance_per_asset_rpc() {
 	ExtBuilder::default()
@@ -873,7 +886,7 @@ fn test_get_user_underlying_balance_per_asset_rpc() {
 			assert_eq!(Currencies::free_balance(ETH, &ALICE::get()), eth_balance_after_repay);
 
 			assert_ok!(MinterestProtocol::redeem(alice(), ETH));
-			// Check that after redeem user ETH balance increased by a value that was previousely returned by
+			// Check that after redeem user ETH balance increased by a value that was previously returned by
 			// get_user_underlying_balance_per_asset
 			assert_eq!(
 				Currencies::free_balance(ETH, &ALICE::get()),


### PR DESCRIPTION
**Description:**

Added RPC to return amount of underlying tokens user currently have in protocol.

**Changes in storage or API:**

Controller:
- getUserUnderlyingBalancePerAsset

Describe storage structure changes or API changes. Make sure to update the [API docs](https://minterestfinance.atlassian.net/wiki/spaces/MINTEREST/pages/134807557/Minterest+API).

**Checklist**

- [ ] Code is covered with tests
- [ ] Code is covered with benchmarks
- [ ] Fresh benchmark results included
