### PR TITLE
EP/MIN-278 Liquidate insolvent loan

### DIFF
--- a/pallets/risk-manager/src/lib.rs
+++ b/pallets/risk-manager/src/lib.rs
@@ -567,7 +567,7 @@ impl<T: Config> Pallet<T> {
 		let mut already_seized_amount = Balance::zero();
 
 		// Make a copy of initial value for the case of lack of collateral.
-		let stamp_of_seize_amount = seize_amount.clone();
+		let stamp_of_seize_amount = seize_amount;
 
 		for collateral_pool_id in collateral_pools.into_iter() {
 			if !seize_amount.is_zero() {

--- a/pallets/risk-manager/src/tests.rs
+++ b/pallets/risk-manager/src/tests.rs
@@ -272,10 +272,7 @@ fn liquidate_should_work() {
 		assert_noop!(TestRiskManager::liquidate(Origin::signed(ALICE), ALICE, DOT), BadOrigin);
 
 		// Origin::none is available origin for fn liquidate.
-		assert_noop!(
-			TestRiskManager::liquidate(Origin::none(), ALICE, DOT),
-			minterest_protocol::Error::<Test>::ZeroBalanceTransaction
-		);
+		assert_ok!(TestRiskManager::liquidate(Origin::none(), ALICE, DOT));
 	})
 }
 

--- a/runtime/src/tests/balancing_pools_tests.rs
+++ b/runtime/src/tests/balancing_pools_tests.rs
@@ -20,13 +20,6 @@ fn collects_sales_list_should_work_2_2() {
 		.liquidation_pool_balance(BTC, 100_000 * DOLLARS)
 		.build()
 		.execute_with(|| {
-			// The function unlock_price() call is necessary because asset values are
-			// locked in the genesis block. Values are locked because the mnt-token pallet
-			// in the method build() uses asset prices.
-			vec![DOT, KSM, BTC, ETH].into_iter().for_each(|pool_id| {
-				assert_ok!(Prices::unlock_price(origin_root(), pool_id));
-			});
-
 			let prices: Vec<(CurrencyId, Price)> = vec![
 				(DOT, Price::saturating_from_integer(30)),
 				(KSM, Price::saturating_from_integer(5)),
@@ -87,13 +80,6 @@ fn balance_liquidation_pools_should_work() {
 		.dex_balance(BTC, 500_000 * DOLLARS)
 		.build()
 		.execute_with(|| {
-			// The function unlock_price() call is necessary because asset values are
-			// locked in the genesis block. Values are locked because the mnt-token pallet
-			// in the method build() uses asset prices.
-			vec![DOT, KSM, BTC, ETH].into_iter().for_each(|pool_id| {
-				assert_ok!(Prices::unlock_price(origin_root(), pool_id));
-			});
-
 			let prices: Vec<(CurrencyId, Price)> = vec![
 				(DOT, Price::saturating_from_integer(1)),
 				(KSM, Price::saturating_from_integer(2)),
@@ -189,13 +175,6 @@ fn balance_liquidation_pools_two_pools_should_work_test() {
 		.dex_balance(ETH, 500_000 * DOLLARS)
 		.build()
 		.execute_with(|| {
-			// The function unlock_price() call is necessary because asset values are
-			// locked in the genesis block. Values are locked because the mnt-token pallet
-			// in the method build() uses asset prices.
-			vec![DOT, KSM, BTC, ETH].into_iter().for_each(|pool_id| {
-				assert_ok!(Prices::unlock_price(origin_root(), pool_id));
-			});
-
 			let prices: Vec<(CurrencyId, Price)> = vec![
 				(DOT, Price::saturating_from_integer(2)),
 				(ETH, Price::saturating_from_integer(4)),

--- a/runtime/src/tests/liquidation_tests.rs
+++ b/runtime/src/tests/liquidation_tests.rs
@@ -204,7 +204,7 @@ Description of scenario:
 This scenario handles the case, when user has not enough collateral to cover liquidation.
 This is a rare but possible case (may be caused by Flash Crashes of BTC or outage of oracles).
 This is a VERY painful case.
-The algorithm performs liquidation, liquidation pool repays full user's loan, even in case if there
+The algorithm performs liquidation: liquidation pool repays full user's loan, even in case if there
 is not enough collateral and burn all available user's collateral.
  */
 #[test]
@@ -296,8 +296,7 @@ Description of scenario:
 This scenario handles the case, when user has not enough collateral to cover liquidation and user's
 liquidation attempts are equal to zero.
 This is a rare but possible case (may be caused by Flash Crashes of BTC or outage of oracles).
-The algorithm performs liquidation, liquidation pool can not repay full user's loan, all available
-user's collateral is burned, the part of borrow balance and collateral remains with the user,
+The algorithm performs liquidation: liquidation pool can not repay full user's loan, the part of borrow balance and collateral remains with the user,
 DepletedLiquidationPool event is emitted.
  */
 #[test]

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -369,13 +369,7 @@ impl ExtBuilder {
 		.unwrap();
 
 		module_prices::GenesisConfig::<Runtime> {
-			locked_price: vec![
-				(DOT, Rate::saturating_from_integer(2)),
-				(KSM, Rate::saturating_from_integer(2)),
-				(ETH, Rate::saturating_from_integer(2)),
-				(BTC, Rate::saturating_from_integer(2)),
-				(MNT, Rate::saturating_from_integer(4)),
-			],
+			locked_price: vec![(MNT, Rate::saturating_from_integer(4))],
 			_phantom: PhantomData,
 		}
 		.assimilate_storage(&mut t)

--- a/runtime/src/tests/rpc_tests.rs
+++ b/runtime/src/tests/rpc_tests.rs
@@ -818,6 +818,9 @@ fn get_user_total_collateral_rpc_should_work() {
 #[test]
 fn test_get_user_underlying_balance_per_asset_rpc() {
 	ExtBuilder::default().pool_initial(ETH).build().execute_with(|| {
+		// Set price = 2.00 USD for all pools.
+		assert_ok!(set_oracle_price_for_all_pools(2));
+
 		assert_ok!(MinterestProtocol::deposit_underlying(bob(), ETH, dollars(90_000)));
 		// Alice deposited ALL ETH tokens to protocol
 		assert_ok!(MinterestProtocol::deposit_underlying(alice(), ETH, dollars(100_000)));
@@ -914,6 +917,9 @@ fn get_unclaimed_mnt_balance_should_work() {
 		.pool_initial(BTC)
 		.build()
 		.execute_with(|| {
+			// Set price = 2.00 USD for all pools.
+			assert_ok!(set_oracle_price_for_all_pools(2));
+
 			// Set initial state of pools for distribution MNT tokens.
 			assert_ok!(MinterestProtocol::deposit_underlying(bob(), DOT, 100_000 * DOLLARS));
 			assert_ok!(MinterestProtocol::enable_is_collateral(bob(), DOT));
@@ -980,6 +986,9 @@ fn get_mnt_borrow_and_supply_rates_should_work() {
 		.set_mnt_rate(10)
 		.build()
 		.execute_with(|| {
+			// Set price = 2.00 USD for all pools.
+			assert_ok!(set_oracle_price_for_all_pools(2));
+
 			assert_ok!(MinterestProtocol::deposit_underlying(alice(), DOT, 10_000 * DOLLARS));
 			assert_ok!(MinterestProtocol::deposit_underlying(alice(), ETH, 15_000 * DOLLARS));
 			assert_ok!(MinterestProtocol::deposit_underlying(bob(), BTC, 25_000 * DOLLARS));


### PR DESCRIPTION
**Description:**

Fix logic of liquidation.
Add check for case when user dosn't have enought collateral to repay the dept.
Add event which is emmited when LiquidationPool is almost or fully depleted.

Add test.
This test shows that in case when user has unsecured debt in excess of his collateral and liquidation pool available liquidity, we don't liquidate him completely, despite the fact that he has collateral.

**Changes in storage or API:**

Describe storage structure changes or API changes. Make sure to update the [API docs](https://minterestfinance.atlassian.net/wiki/spaces/MINTEREST/pages/134807557/Minterest+API).

**Checklist**
- [x] Code is covered with tests
- [ ] Code is covered with benchmarks
- [ ] Fresh benchmark results included
